### PR TITLE
s/processd: implement service YAMLs

### DIFF
--- a/kernel/arch/x86/components/rtc.c
+++ b/kernel/arch/x86/components/rtc.c
@@ -31,6 +31,7 @@
 #include <hpet.h>
 #include <interrupts.h>
 #include <machine.h>
+#include <stdlib.h>
 
 // import the calibration ticker as we use it during boot
 extern uint32_t g_calibrationTick;

--- a/librt/libc/dl/dlfcn.c
+++ b/librt/libc/dl/dlfcn.c
@@ -31,7 +31,7 @@ dlopen (
     // RTLD_LAZY is not supported
     // RTLD_NOW is default behaviour
     _CRT_UNUSED(mode);
-    return (void*)SharedObjectLoad(filepath);
+    return (void*)OSLibraryLoad(filepath);
 }
 
 int
@@ -39,7 +39,7 @@ dlclose(
     _In_ void* handle)
 {
     // OS_EOK resolves to 0 luckily
-    return (int)SharedObjectUnload((Handle_t)handle);
+    return (int)OSLibraryUnload((Handle_t)handle);
 }
 
 void*
@@ -47,7 +47,7 @@ dlsym(
     _In_ void* restrict       handle,
     _In_ const char* restrict name)
 {
-    return SharedObjectGetFunction((Handle_t)handle, name);
+    return OSLibraryLookupFunction((Handle_t)handle, name);
 }
 
 char*

--- a/librt/libc/libc.def
+++ b/librt/libc/libc.def
@@ -22,8 +22,8 @@ usched_rwlock_w_promote
 usched_rwlock_w_demote
 usched_rwlock_w_lock
 usched_rwlock_w_unlock
-Mount
-Unmount
+OSMount
+OSUnmount
 __crt_process_initialize
 __crt_cmdline
 abort

--- a/librt/libddk/include/ddk/service.h
+++ b/librt/libddk/include/ddk/service.h
@@ -29,6 +29,23 @@
 
 _CODE_BEGIN
 
+// imported from gracht types.h, to avoid including that header
+typedef struct gracht_server gracht_server_t;
+
+struct ServiceStartupOptions {
+    // Server is the handle to the gracht server itself. This is exposed to allow
+    // services to register the protocols they support.
+    gracht_server_t* Server;
+    // ServerHandle is the handle of gracht server link. This is exposed to allow
+    // services to share their handle with other procceses to allow communication.
+    // While this is possible to discover with just the above Server handle, we add
+    // it here for convenience.
+    uuid_t ServerHandle;
+};
+
+// While we no longer hardcode these paths in the code when setting them, we still hardcode
+// them when discovering. This means that we cannot remove these just yet, and instead they must
+// match the service YAML paths.
 #define SERVICE_SESSION_PATH "/service/session"
 #define SERVICE_DEVICE_PATH "/service/device"
 #define SERVICE_USB_PATH "/service/usb"

--- a/librt/libos/include/os/services/mount.h
+++ b/librt/libos/include/os/services/mount.h
@@ -37,7 +37,7 @@ _CODE_BEGIN
  * @return
  */
 CRTDECL(oserr_t,
-Mount(
+OSMount(
         _In_ const char*  path,
         _In_ const char*  at,
         _In_ const char*  type,
@@ -49,7 +49,7 @@ Mount(
  * @return
  */
 CRTDECL(oserr_t,
-Unmount(
+OSUnmount(
         _In_ const char* path));
 
 _CODE_END

--- a/librt/libos/include/os/services/sharedobject.h
+++ b/librt/libos/include/os/services/sharedobject.h
@@ -33,7 +33,7 @@ _CODE_BEGIN
  * @return
  */
 CRTDECL(Handle_t,
-SharedObjectLoad(
+OSLibraryLoad(
         _In_ const char* library));
 
 /**
@@ -44,18 +44,19 @@ SharedObjectLoad(
  * @return
  */
 CRTDECL(void*,
-SharedObjectGetFunction(
+OSLibraryLookupFunction(
         _In_ Handle_t    handle,
         _In_ const char* function));
 
 /**
  * @brief Unloads a valid shared object handle
- * @param Handle
+ * @param handle
  * @return
  */
 CRTDECL(oserr_t,
-SharedObjectUnload(
-        _In_ Handle_t Handle));
+OSLibraryUnload(
+        _In_ Handle_t handle));
+
 _CODE_END
 
 #endif //!__OS_SERVICES_SHAREDOBJECT_H__

--- a/librt/libos/services/mount.c
+++ b/librt/libos/services/mount.c
@@ -25,7 +25,7 @@
 #include <sys_mount_service_client.h>
 
 oserr_t
-Mount(
+OSMount(
         _In_ const char*  path,
         _In_ const char*  at,
         _In_ const char*  type,
@@ -49,7 +49,7 @@ Mount(
 }
 
 oserr_t
-Unmount(
+OSUnmount(
         _In_ const char* path)
 {
     struct vali_link_message msg = VALI_MSG_INIT_HANDLE(GetFileService());

--- a/librt/libos/services/shared_objects.c
+++ b/librt/libos/services/shared_objects.c
@@ -58,7 +58,7 @@ static void __InitializeSO(void)
 }
 
 Handle_t 
-SharedObjectLoad(
+OSLibraryLoad(
 	_In_ const char* SharedObject)
 {
     struct vali_link_message msg = VALI_MSG_INIT_HANDLE(GetProcessService());
@@ -130,7 +130,7 @@ SharedObjectLoad(
 }
 
 void*
-SharedObjectGetFunction(
+OSLibraryLookupFunction(
 	_In_ Handle_t       handle,
 	_In_ const char*    function)
 {
@@ -167,7 +167,7 @@ struct so_enum_context {
 };
 
 oserr_t
-SharedObjectUnload(
+OSLibraryUnload(
 	_In_ Handle_t handle)
 {
     SOInitializer_t        initialize = NULL;

--- a/services/deviced/deviced.yaml
+++ b/services/deviced/deviced.yaml
@@ -1,5 +1,5 @@
-# Standard yaml configuration for services in the OS
 service:
-  name: deviced
+  # The service API path, for other instances to expect connection through.
+  # These API paths are registered upon startup of the service, and allows an
+  # easy way to recognize system services.
   path: /service/device
-  #depends: none

--- a/services/deviced/main.c
+++ b/services/deviced/main.c
@@ -33,20 +33,11 @@
 #include <sys_device_service_server.h>
 #include <ctt_driver_service_client.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void
-GetServiceAddress(
-        _In_ IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_DEVICE_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_device_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_device_server_protocol);
 
     // Register the client control protocol
     gracht_client_register_protocol(GetGrachtClient(), &ctt_driver_client_protocol);

--- a/services/filed/filed.yaml
+++ b/services/filed/filed.yaml
@@ -1,5 +1,5 @@
-# Standard yaml configuration for services in the OS
 service:
-  name: filed
+  # The service API path, for other instances to expect connection through.
+  # These API paths are registered upon startup of the service, and allows an
+  # easy way to recognize system services.
   path: /service/file
-  #depends: none

--- a/services/filed/main.c
+++ b/services/filed/main.c
@@ -22,20 +22,14 @@
 #include <vfs/scope.h>
 #include <vfs/storage.h>
 #include <vfs/vfs.h>
+#include <stdlib.h>
 
 #include <sys_file_service_server.h>
 #include <sys_mount_service_server.h>
 #include <sys_storage_service_server.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void GetServiceAddress(IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_FILE_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     oserr_t oserr;
 
@@ -52,7 +46,7 @@ void ServiceInitialize(void)
     }
 
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_file_server_protocol);
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_mount_server_protocol);
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_storage_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_file_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_mount_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_storage_server_protocol);
 }

--- a/services/netd/main.c
+++ b/services/netd/main.c
@@ -25,23 +25,16 @@
 //#define __TRACE
 
 #include <ddk/service.h>
-#include <ddk/utils.h>
 #include "manager.h"
+#include <stdlib.h>
 
 #include <sys_socket_service_server.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void GetServiceAddress(IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_NET_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_socket_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_socket_server_protocol);
 
     // Initialize the subsystems
     if (NetworkManagerInitialize() != OS_EOK) {

--- a/services/netd/netd.yaml
+++ b/services/netd/netd.yaml
@@ -1,5 +1,5 @@
-# Standard yaml configuration for services in the OS
 service:
-  name: netd
+  # The service API path, for other instances to expect connection through.
+  # These API paths are registered upon startup of the service, and allows an
+  # easy way to recognize system services.
   path: /service/net
-  #depends: none

--- a/services/processd/CMakeLists.txt
+++ b/services/processd/CMakeLists.txt
@@ -11,6 +11,11 @@ else ()
     message(FATAL "phoenix: unsupported architecture ${VALI_ARCH}")
 endif ()
 
+# Include any sub-projects here
+add_subdirectory(debugger)
+add_subdirectory(pe)
+add_subdirectory(services)
+
 set (ADDITONAL_SOURCES
     ${CMAKE_BINARY_DIR}/protocols/sys_library_service_server.c
     ${CMAKE_BINARY_DIR}/protocols/sys_process_service_server.c
@@ -20,24 +25,6 @@ set_source_files_properties ( ${ADDITONAL_SOURCES} PROPERTIES GENERATED TRUE )
 add_executable (phoenix
         ${ADDITONAL_SOURCES}
 
-        bootstrap/discover.c
-
-        pe/cache.c
-        pe/imports.c
-        pe/load_context.c
-        pe/loader.c
-        pe/mapper.c
-        pe/module.c
-        pe/parse.c
-        pe/resolver.c
-        pe/rtrelocs.c
-        pe/utilities.c
-        pe/verify.c
-
-        debugger/debugger.c
-        debugger/map_parser.c
-        debugger/symbol_loader.c
-
         main.c
         process.c
         requests.c
@@ -46,10 +33,10 @@ add_executable (phoenix
 target_include_directories(phoenix PRIVATE include)
 target_compile_options(phoenix PRIVATE -nostdlib -Wno-address-of-packed-member)
 target_link_options(phoenix PRIVATE "LINKER:-entry:__phoenix_main,-fixed,-base:${PHOENIX_BASE_ADDRESS}")
-set_target_properties (phoenix
+set_target_properties(phoenix
         PROPERTIES
             OUTPUT_NAME "phoenix"
             SUFFIX ".mos"
 )
-target_link_libraries (phoenix libds libddk librt gracht_static vafs libc libm)
+target_link_libraries(phoenix processd-debugger processd-pelib processd-services libds libddk librt gracht_static libm)
 add_dependencies(phoenix service_servers)

--- a/services/processd/debugger/CMakeLists.txt
+++ b/services/processd/debugger/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(processd-debugger
+        debugger.c
+        map_parser.c
+        symbol_loader.c
+)
+target_include_directories(processd-debugger PRIVATE ../include)
+target_compile_options(processd-debugger PRIVATE -nostdlib -Wno-address-of-packed-member)
+target_link_libraries(processd-debugger PUBLIC libc)

--- a/services/processd/include/discover.h
+++ b/services/processd/include/discover.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022, Philip Meulengracht
+ *
+ * This program is free software : you can redistribute it and / or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation ? , either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __PHOENIX_DISCOVER_H__
+#define __PHOENIX_DISCOVER_H__
+
+#include <ds/mstring.h>
+#include <ds/list.h>
+
+struct SystemService {
+    int        ID;
+    mstring_t* Name;
+    mstring_t* Path;
+    mstring_t* APIPath;
+    // Dependencies is a list of service names this service requires
+    // before it is spawned.
+    list_t Dependencies;
+};
+
+/**
+ * @brief Bootstraps the entire system by parsing ramdisk for system services.
+ */
+extern void PSBootstrap(void*, void*);
+
+/**
+ * @brief Cleans up any resources related to bootstrapping. This includes the mapped
+ * ramdisk, which should only be cleaned up on process exit.
+ */
+extern void PSBootstrapCleanup(void);
+
+/**
+ * @brief
+ * @param systemService
+ * @param yaml
+ * @param length
+ * @return
+ */
+oserr_t
+PSParseServiceYAML(
+        _In_ struct SystemService* systemService,
+        _In_ const uint8_t*        yaml,
+        _In_ size_t                length);
+
+#endif //!__PHOENIX_DISCOVER_H__

--- a/services/processd/include/pe.h
+++ b/services/processd/include/pe.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Philip Meulengracht
+ * Copyright 2022, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,11 +13,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- *
- * PE/COFF Image Loader
- *    - Implements support for loading and processing pe/coff image formats
- *      and implemented as a part of libds to share between services and kernel
  */
 
 #ifndef __PE_IMAGE_LOADER__

--- a/services/processd/include/process.h
+++ b/services/processd/include/process.h
@@ -76,17 +76,6 @@ extern void PmInitialize(void);
 extern void PmDebuggerInitialize(void);
 
 /**
- * @brief Bootstraps the entire system by parsing ramdisk for system services.
- */
-extern void PmBootstrap(void*, void*);
-
-/**
- * @brief Cleans up any resources related to bootstrapping. This includes the mapped
- * ramdisk, which should only be cleaned up on process exit.
- */
-extern void PmBootstrapCleanup(void);
-
-/**
  * @brief
  *
  * @param path

--- a/services/processd/main.c
+++ b/services/processd/main.c
@@ -20,6 +20,7 @@
  *   of running applications.
  */
 
+#include <discover.h>
 #include <internal/_ipc.h>
 #include <os/usched/job.h>
 #include <process.h>
@@ -47,5 +48,5 @@ void ServiceInitialize(void)
     PECacheInitialize();
 
     // Queue up the bootstrap function
-    usched_job_queue(PmBootstrap, NULL);
+    usched_job_queue(PSBootstrap, NULL);
 }

--- a/services/processd/main.c
+++ b/services/processd/main.c
@@ -28,19 +28,12 @@
 #include <sys_library_service_server.h>
 #include <sys_process_service_server.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void GetServiceAddress(IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_PROCESS_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_library_server_protocol);
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_process_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_library_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_process_server_protocol);
 
     // Initialize all our subsystems for Phoenix
     PmInitialize();

--- a/services/processd/pe/CMakeLists.txt
+++ b/services/processd/pe/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(processd-pelib
+        cache.c
+        imports.c
+        load_context.c
+        loader.c
+        mapper.c
+        module.c
+        parse.c
+        resolver.c
+        rtrelocs.c
+        utilities.c
+        verify.c
+)
+target_include_directories(processd-pelib PRIVATE ../include)
+target_compile_options(processd-pelib PRIVATE -nostdlib -Wno-address-of-packed-member)
+target_link_libraries(processd-pelib PUBLIC libc)

--- a/services/processd/services/CMakeLists.txt
+++ b/services/processd/services/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(processd-services
+        discover.c
+        parser.c
+)
+target_include_directories(processd-services PRIVATE ../include)
+target_compile_options(processd-services PRIVATE -nostdlib -Wno-address-of-packed-member)
+target_link_libraries(processd-services PUBLIC libyaml vafs libc)

--- a/services/served/served.yaml
+++ b/services/served/served.yaml
@@ -1,8 +1,4 @@
-# Standard yaml configuration for services in the OS
 service:
-  # The global unique identifier for the system service
-  name: served
-
   # The service API path, for other instances to expect connection through.
   # These API paths are registered upon startup of the service, and allows an
   # easy way to recognize system services.

--- a/services/served/server/application.c
+++ b/services/served/server/application.c
@@ -296,7 +296,7 @@ oserr_t ApplicationMount(
 
     // First thing we do is mount the application, and then we prepare a mount space
     // for the application.
-    oserr = Mount(packPath, mountPath, "valifs", MOUNT_FLAG_READ);
+    oserr = OSMount(packPath, mountPath, "valifs", MOUNT_FLAG_READ);
     if (oserr != OS_EOK) {
         ERROR("ApplicationMount failed to mount application %ms: %u",
               application->Name, oserr);
@@ -400,7 +400,7 @@ oserr_t ApplicationUnmount(struct Application* application)
         }
     }
 
-    oserr = Unmount(mountPath);
+    oserr = OSUnmount(mountPath);
     if (oserr != OS_EOK) {
         ERROR("ApplicationUnmount failed to unmount application %ms", application->Name);
     }

--- a/services/sessiond/main.c
+++ b/services/sessiond/main.c
@@ -28,18 +28,11 @@
 
 #include <sys_session_service_server.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void GetServiceAddress(IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_SESSION_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_session_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_session_server_protocol);
 }
 
 void sys_session_login_invocation(struct gracht_message* message, const char* user, const char* password)

--- a/services/sessiond/sessiond.yaml
+++ b/services/sessiond/sessiond.yaml
@@ -1,5 +1,5 @@
-# Standard yaml configuration for services in the OS
 service:
-  name: sessiond
+  # The service API path, for other instances to expect connection through.
+  # These API paths are registered upon startup of the service, and allows an
+  # easy way to recognize system services.
   path: /service/session
-  #depends: none

--- a/services/usbd/main.c
+++ b/services/usbd/main.c
@@ -26,21 +26,15 @@
 #include <gracht/link/vali.h>
 #include "manager.h"
 #include <usb/usb.h>
+#include <stdlib.h>
 
 #include <sys_usb_service_server.h>
 
-extern gracht_server_t* __crt_get_service_server(void);
-
-void GetServiceAddress(IPCAddress_t* address)
-{
-    address->Type = IPC_ADDRESS_PATH;
-    address->Data.Path = SERVICE_USB_PATH;
-}
-
-void ServiceInitialize(void)
+void ServiceInitialize(
+        _In_ struct ServiceStartupOptions* startupOptions)
 {
     // Register supported interfaces
-    gracht_server_register_protocol(__crt_get_service_server(), &sys_usb_server_protocol);
+    gracht_server_register_protocol(startupOptions->Server, &sys_usb_server_protocol);
 
     // Initialize all subsystems
     if (UsbCoreInitialize() != OS_EOK) {

--- a/services/usbd/usbd.yaml
+++ b/services/usbd/usbd.yaml
@@ -1,5 +1,5 @@
-# Standard yaml configuration for services in the OS
 service:
-  name: usbd
+  # The service API path, for other instances to expect connection through.
+  # These API paths are registered upon startup of the service, and allows an
+  # easy way to recognize system services.
   path: /service/usb
-  #depends: none


### PR DESCRIPTION
This should hopefully we the last PR before the 0.8 release. This implements support for service configuration YAMLs and cleans up a bit in our OS API.

Bugfixes:

Improvements:
- Use sub-directory projects in phoenix, cleaning up a bit.
- Services now support --api-path and --token arguments which we will need.
- Cleanup SO and Mount API
- Cleanup service YAML files

Features:
- We can now configure services using YAML files.
- Services are now provided startup options in their ServiceInitialize function that allows services to store a few variables instead of providing __crt* methods for this.