### PR TITLE
usb: remaining fixes after usb common code refactoring

### DIFF
--- a/kernel/include/shm.h
+++ b/kernel/include/shm.h
@@ -65,7 +65,7 @@ SHMExport(
 KERNELAPI oserr_t KERNELABI
 SHMConform(
         _In_ uuid_t                  shmID,
-        _In_ enum OSMemoryConformity conformity,
+        _In_ SHMConformityOptions_t* conformity,
         _In_ unsigned int            flags,
         _In_ unsigned int            access,
         _In_ size_t                  offset,

--- a/librt/libc/io/open.c
+++ b/librt/libc/io/open.c
@@ -206,7 +206,7 @@ __read_large(
         TRACE("__read_large: aligning buffer=0x%" PRIxIN ", align=0x%" PRIxIN,
               buffer, bytesToAlign);
         oserr = __file_read(handle, buffer, bytesToAlign, bytesReadOut);
-        if (oserr != OS_EOK) {
+        if (oserr != OS_EOK || *bytesReadOut == 0) {
             return oserr;
         }
         adjustedPointer = (void*)((uintptr_t)buffer + bytesToAlign);
@@ -302,7 +302,7 @@ __write_large(
         TRACE("__write_large: aligning buffer=0x%" PRIxIN ", align=0x%" PRIxIN,
               buffer, bytesToAlign);
         oserr = __file_write(handle, buffer, bytesToAlign, bytesWrittenOut);
-        if (oserr != OS_EOK) {
+        if (oserr != OS_EOK|| *bytesWrittenOut == 0) {
             return oserr;
         }
         adjustedPointer = (void*)((uintptr_t)buffer + bytesToAlign);

--- a/librt/libc/os/init.c
+++ b/librt/libc/os/init.c
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define __TRACE
+//#define __TRACE
 #define __need_quantity
 
 #include <assert.h>

--- a/librt/libc/stdio/fwrite.c
+++ b/librt/libc/stdio/fwrite.c
@@ -40,6 +40,7 @@ __prewrite_buffer(
         return 0;
     }
 
+    TRACE("__prewrite_buffer: current=0x%llx, bytesToWrite=%i", stream->Current, bytesToWrite);
     memcpy(stream->Current, buffer, bytesToWrite);
 
     stream->Current += bytesToWrite;
@@ -78,7 +79,7 @@ size_t fwrite(const void* vptr, size_t size, size_t count, FILE* stream)
     io_buffer_ensure(stream);
 
     // Fill the buffer before continuing, and flush if neccessary.
-    if (__FILE_IsBuffered(stream)) {
+    if (__FILE_IsBuffered(stream) && __FILE_BufferPosition(stream) > 0) {
         int bytesAvailable = stream->BufferSize - __FILE_BufferPosition(stream);
         int bytesWritten = __prewrite_buffer(stream, vptr, (int)wrcnt);
         if (bytesWritten) {

--- a/librt/libddk/include/ddk/utils.h
+++ b/librt/libddk/include/ddk/utils.h
@@ -29,6 +29,7 @@
 /* Global <always-on> definitions
  * These are enabled no matter which kind of debugging is enabled */
 #define STR(str)               str
+#define NOTICE(...)            SystemDebug(OSSYSLOGLEVEL_TRACE, __VA_ARGS__)
 #define DEBUG(...)             SystemDebug(OSSYSLOGLEVEL_DEBUG, __VA_ARGS__)
 #define WARNING(...)           SystemDebug(OSSYSLOGLEVEL_WARNING, __VA_ARGS__)
 #define WARNING_IF(cond, ...)  { if ((cond)) { SystemDebug(OSSYSLOGLEVEL_WARNING, __VA_ARGS__); } }

--- a/librt/libddk/include/ddk/utils.h
+++ b/librt/libddk/include/ddk/utils.h
@@ -31,11 +31,11 @@
 #define STR(str)               str
 #define DEBUG(...)             SystemDebug(OSSYSLOGLEVEL_DEBUG, __VA_ARGS__)
 #define WARNING(...)           SystemDebug(OSSYSLOGLEVEL_WARNING, __VA_ARGS__)
-#define WARNING_IF(cond, ...)  { if ((cond)) { SystemDebug(SYSTEM_DEBUG_WARNING, __VA_ARGS__); } }
+#define WARNING_IF(cond, ...)  { if ((cond)) { SystemDebug(OSSYSLOGLEVEL_WARNING, __VA_ARGS__); } }
 #define WARNING_ONCE(id, ...)  { \
                                     static _Atomic(int) __gi_ ##id ## _trigger = 0; \
                                     if (!atomic_exchange(&__gi_ ##id ## _trigger, 1)) { \
-                                        SystemDebug(SYSTEM_DEBUG_WARNING, __VA_ARGS__); \
+                                        SystemDebug(OSSYSLOGLEVEL_WARNING, __VA_ARGS__); \
                                     } \
                                }
 #define ERROR(...)	           SystemDebug(OSSYSLOGLEVEL_ERROR, __VA_ARGS__)

--- a/librt/libos/include/os/shm.h
+++ b/librt/libos/include/os/shm.h
@@ -68,7 +68,7 @@ SHMExport(
 CRTDECL(oserr_t,
 SHMConform(
         _In_ uuid_t                  shmID,
-        _In_ enum OSMemoryConformity conformity,
+        _In_ SHMConformityOptions_t* conformity,
         _In_ unsigned int            flags,
         _In_ unsigned int            access,
         _In_ size_t                  offset,

--- a/librt/libos/include/os/types/shm.h
+++ b/librt/libos/include/os/types/shm.h
@@ -124,4 +124,15 @@ typedef struct SHMSGTable {
     int      Count;
 } SHMSGTable_t;
 
+typedef struct SHMConformityOptions {
+    // The alignment the buffer must have to be conformed. An alignment of 0
+    // means no alignment is required. The alignment must *always* be a power
+    // of two.
+    uint32_t BufferAlignment;
+    // The memory conformity is the location in physical memory that the memory
+    // range should reside. This is useful for drivers to specify requirements
+    // in terms of backwards compatability.
+    enum OSMemoryConformity Conformity;
+} SHMConformityOptions_t;
+
 #endif //!__OS_TYPES_SHM_H__

--- a/librt/libos/include/os/types/syscall.h
+++ b/librt/libos/include/os/types/syscall.h
@@ -19,8 +19,9 @@
 #define __TYPES_SYSCALL_H__
 
 #include <os/types/memory.h>
-#include <os/types/time.h>
 #include <os/types/syslog.h>
+#include <os/types/shm.h>
+#include <os/types/time.h>
 #include <time.h> // for clock_t
 
 typedef struct OSKernelLogEntry {
@@ -49,7 +50,7 @@ typedef struct OSFutexParameters {
 } OSFutexParameters_t;
 
 typedef struct OSSHMConformParameters {
-    enum OSMemoryConformity Conformity;
+    SHMConformityOptions_t* Conformity;
     unsigned int            Flags;
     unsigned int            Access;
     size_t                  Offset;

--- a/librt/libos/shm.c
+++ b/librt/libos/shm.c
@@ -159,7 +159,7 @@ SHMExport(
 oserr_t
 SHMConform(
         _In_ uuid_t                  shmID,
-        _In_ enum OSMemoryConformity conformity,
+        _In_ SHMConformityOptions_t* conformity,
         _In_ unsigned int            flags,
         _In_ unsigned int            access,
         _In_ size_t                  offset,

--- a/librt/libusb/include/usb/usb.h
+++ b/librt/libusb/include/usb/usb.h
@@ -39,7 +39,7 @@ DECL_STRUCT(UsbDevice);
 #define USB_DEVICE_CLASS     0x0000CABB
 #define USB_TRANSACTIONCOUNT 3
 
-typedef enum USBTransferCode {
+enum USBTransferCode {
     USBTRANSFERCODE_INVALID,
 
     // HCD Error Codes
@@ -54,7 +54,7 @@ typedef enum USBTransferCode {
     USBTRANSFERCODE_BUFFERERROR,
     USBTRANSFERCODE_NAK,
     USBTRANSFERCODE_BABBLE // CRC/Bitstuffing
-} USBTransferCode_t;
+};
 
 enum USBControllerKind {
     USBCONTROLLER_KIND_UHCI,

--- a/librt/libusb/include/usb/usb.h
+++ b/librt/libusb/include/usb/usb.h
@@ -1,7 +1,5 @@
 /**
- * MollenOS
- *
- * Copyright 2017, Philip Meulengracht
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/eth/intel/CMakeLists.txt
+++ b/modules/eth/intel/CMakeLists.txt
@@ -1,9 +1,3 @@
-if (NOT DEFINED VALI_BUILD)
-    cmake_minimum_required(VERSION 3.13.4)
-    include(../../../cmake/SetupEnvironment.cmake)
-    project(vali-module-eth-intel)
-endif ()
-
 enable_language(C)
 
 # Configure include paths

--- a/modules/filesystems/common/include/fs/common.h
+++ b/modules/filesystems/common/include/fs/common.h
@@ -27,6 +27,7 @@
  * of all filesystem context structures.
  */
 struct FSBaseContext {
+    uint32_t                IOBufferAlignment;
     enum OSMemoryConformity IOConformity;
 };
 

--- a/modules/filesystems/common/requests.c
+++ b/modules/filesystems/common/requests.c
@@ -251,6 +251,7 @@ static inline oserr_t
 __MapUserBufferRead(
         _In_ struct FSBaseContext* fsBaseContext,
         _In_ uuid_t                handle,
+        _In_ size_t                length,
         _In_ OSHandle_t*           shm)
 {
     return SHMConform(
@@ -259,7 +260,7 @@ __MapUserBufferRead(
             SHM_CONFORM_BACKFILL_ON_UNMAP,
             SHM_ACCESS_READ | SHM_ACCESS_WRITE,
             0,
-            SHMBufferCapacity(shm),
+            length,
             shm
     );
 }
@@ -272,7 +273,7 @@ void ctt_filesystem_read_invocation(struct gracht_message* message, const uintpt
     size_t     read;
     TRACE("ctt_filesystem_read_invocation()");
 
-    oserr = __MapUserBufferRead((void*)fsctx, params->buffer_id, &shm);
+    oserr = __MapUserBufferRead((void*)fsctx, params->buffer_id, (size_t)params->count, &shm);
     if (oserr != OS_EOK) {
         ctt_filesystem_read_response(message, oserr, 0);
         return;
@@ -305,6 +306,7 @@ static inline oserr_t
 __MapUserBufferWrite(
         _In_ struct FSBaseContext* fsBaseContext,
         _In_ uuid_t                handle,
+        _In_ size_t                length,
         _In_ OSHandle_t*           shm)
 {
     return SHMConform(
@@ -313,7 +315,7 @@ __MapUserBufferWrite(
             SHM_CONFORM_FILL_ON_CREATION,
             SHM_ACCESS_READ,
             0,
-            SHMBufferCapacity(shm),
+            length,
             shm
     );
 }
@@ -325,7 +327,7 @@ void ctt_filesystem_write_invocation(struct gracht_message* message, const uintp
     size_t     written;
     TRACE("ctt_filesystem_write_invocation()");
 
-    oserr = __MapUserBufferWrite((void*)fsctx, params->buffer_id, &shm);
+    oserr = __MapUserBufferWrite((void*)fsctx, params->buffer_id, (size_t)params->count, &shm);
     if (oserr != OS_EOK) {
         ctt_filesystem_write_response(message, oserr, 0);
         return;

--- a/modules/filesystems/common/requests.c
+++ b/modules/filesystems/common/requests.c
@@ -256,7 +256,10 @@ __MapUserBufferRead(
 {
     return SHMConform(
             handle,
-            fsBaseContext->IOConformity,
+            &(SHMConformityOptions_t) {
+                .BufferAlignment = fsBaseContext->IOBufferAlignment,
+                .Conformity = fsBaseContext->IOConformity
+            },
             SHM_CONFORM_BACKFILL_ON_UNMAP,
             SHM_ACCESS_READ | SHM_ACCESS_WRITE,
             0,
@@ -311,7 +314,10 @@ __MapUserBufferWrite(
 {
     return SHMConform(
             handle,
-            fsBaseContext->IOConformity,
+            &(SHMConformityOptions_t) {
+                    .BufferAlignment = fsBaseContext->IOBufferAlignment,
+                    .Conformity = fsBaseContext->IOConformity
+            },
             SHM_CONFORM_FILL_ON_CREATION,
             SHM_ACCESS_READ,
             0,

--- a/modules/filesystems/common/storage.c
+++ b/modules/filesystems/common/storage.c
@@ -48,9 +48,11 @@ FSBaseContextInitialize(
             if (oserr != OS_EOK) {
                 return oserr;
             }
+            fsBaseContext->IOBufferAlignment = ioRequirements.BufferAlignment;
             fsBaseContext->IOConformity = ioRequirements.Conformity;
         } break;
         case VFSSTORAGE_TYPE_FILE: {
+            fsBaseContext->IOBufferAlignment = 0;
             fsBaseContext->IOConformity = OSMEMORYCONFORMITY_NONE;
         } break;
     }

--- a/modules/filesystems/mfs/directory_operations.c
+++ b/modules/filesystems/mfs/directory_operations.c
@@ -150,10 +150,7 @@ FsReadFromDirectory(
         if (position == (entry->BucketByteBoundary + bucketSize)) {
             TRACE("read_metrics::position %u, limit %u", LODWORD(position),
                 LODWORD(entry->BucketByteBoundary + bucketSize));
-            oserr = MFSAdvanceToNextBucket(
-                    mfs, entry,
-                    mfs->SectorsPerBucket * mfs->SectorSize
-            );
+            oserr = MFSAdvanceToNextBucket(mfs, entry);
             if (oserr != OS_EOK) {
                 if (oserr == OS_ENOENT) {
                     oserr = OS_EOK;

--- a/modules/filesystems/mfs/mfs.h
+++ b/modules/filesystems/mfs/mfs.h
@@ -321,14 +321,12 @@ MFSBucketMapSetLinkAndLength(
  * @brief
  * @param mfs
  * @param entry
- * @param bucketSizeBytes
  * @return
  */
 extern oserr_t
 MFSAdvanceToNextBucket(
         _In_ FileSystemMFS_t* mfs,
-        _In_ MFSEntry_t*      entry,
-        _In_ size_t           bucketSizeBytes);
+        _In_ MFSEntry_t*      entry);
 
 /* MfsZeroBucket
  * Wipes the given bucket and count with zero values

--- a/modules/input/hid/hid.c
+++ b/modules/input/hid/hid.c
@@ -175,9 +175,8 @@ HidDevice_t*
 HidDeviceCreate(
     _In_ UsbDevice_t* usbDevice)
 {
-    HidDevice_t*         hidDevice;
-    enum USBTransferCode status;
-    oserr_t              oserr;
+    HidDevice_t* hidDevice;
+    oserr_t      oserr;
 
     TRACE("HidDeviceCreate(usbDevice=0x%" PRIxIN ")", usbDevice);
 

--- a/modules/serial/usb/common/hci.h
+++ b/modules/serial/usb/common/hci.h
@@ -1,6 +1,5 @@
-/* MollenOS
- *
- * Copyright 2011 - 2017, Philip Meulengracht
+/**
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,13 +45,14 @@ extern void
 HCIControllerDestroy(
     _In_ UsbManagerController_t* controller);
 
-extern int
+extern oserr_t
 HCITransferElementsNeeded(
-        _In_ UsbManagerTransfer_t*     transfer,
-        _In_ uint32_t                  transferLength,
-        _In_ enum USBTransferDirection direction,
-        _In_ SHMSGTable_t*             sgTable,
-        _In_ uint32_t                  sgTableOffset);
+        _In_  UsbManagerTransfer_t*     transfer,
+        _In_  uint32_t                  transferLength,
+        _In_  enum USBTransferDirection direction,
+        _In_  SHMSGTable_t*             sgTable,
+        _In_  uint32_t                  sgTableOffset,
+        _Out_ int*                      elementCountOut);
 
 extern void
 HCITransferElementFill(
@@ -85,7 +85,7 @@ extern void
 HCIPortStatus(
         _In_ UsbManagerController_t* controller,
         _In_ int                     index,
-        _In_ USBPortDescriptor_t*  port);
+        _In_ USBPortDescriptor_t*    port);
 
 /**
  * @brief Invoked by the USB common code every time queue elements

--- a/modules/serial/usb/common/manager.c
+++ b/modules/serial/usb/common/manager.c
@@ -1,7 +1,5 @@
 /**
- * MollenOS
- *
- * Copyright 2017, Philip Meulengracht
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +20,7 @@
  *   for all the usb drivers
  */
 
-#define __TRACE
+//#define __TRACE
 
 #include <assert.h>
 #include <ddk/service.h>

--- a/modules/serial/usb/common/scheduler.c
+++ b/modules/serial/usb/common/scheduler.c
@@ -378,7 +378,7 @@ UsbSchedulerAllocateElement(
         break;
     }
     spinlock_release(&Scheduler->Lock);
-    return (i == sPool->ElementCount) ? OS_EUNKNOWN : OS_EOK;
+    return (i == sPool->ElementCount) ? OS_ENOENT : OS_EOK;
 }
 
 oserr_t

--- a/modules/serial/usb/common/scheduler.h
+++ b/modules/serial/usb/common/scheduler.h
@@ -161,7 +161,7 @@ typedef struct UsbScheduler {
 /* UsbSchedulerSettingsCreate
  * Initializes a new instance of the settings to customize the
  * scheduler. */
-__EXTERN void
+extern void
 UsbSchedulerSettingsCreate(
     _In_ UsbSchedulerSettings_t* Settings,
     _In_ size_t                  FrameCount,
@@ -172,7 +172,7 @@ UsbSchedulerSettingsCreate(
 /* UsbSchedulerSettingsConfigureFrameList
  * Configure the framelist settings for the scheduler. This is always
  * neccessary to call if the controller is supplying its own framelist. */
-__EXTERN void
+extern void
 UsbSchedulerSettingsConfigureFrameList(
     _In_ UsbSchedulerSettings_t*    Settings,
     _In_ reg32_t*                   FrameList,
@@ -181,7 +181,7 @@ UsbSchedulerSettingsConfigureFrameList(
 /* UsbSchedulerSettingsAddPool
  * Adds a new pool to the scheduler configuration that will get created
  * with the scheduler. */
-__EXTERN void
+extern void
 UsbSchedulerSettingsAddPool(
     _In_ UsbSchedulerSettings_t*    Settings,
     _In_ size_t                     ElementSize,
@@ -196,7 +196,7 @@ UsbSchedulerSettingsAddPool(
  * Initializes a new instance of a scheduler that can be used to
  * keep track of controller bandwidth and which frames are active.
  * MaxBandwidth is usually either 800 or 900. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerInitialize(
 	_In_  UsbSchedulerSettings_t*   Settings,
     _Out_ UsbScheduler_t**          SchedulerOut);
@@ -204,7 +204,7 @@ UsbSchedulerInitialize(
 /* UsbSchedulerDestroy 
  * Cleans up any resources allocated by the scheduler. Any transactions already
  * scheduled by this scheduler will be unreachable and invalid after this call. */
-__EXTERN void
+extern void
 UsbSchedulerDestroy(
 	_In_ UsbScheduler_t*            Scheduler);
 
@@ -212,20 +212,20 @@ UsbSchedulerDestroy(
  * Reinitializes all data structures in the scheduler to initial state. 
  * This should never be called unless the associating controller is in a
  * stopped state as the framelist is affected. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerResetInternalData(
     _In_ UsbScheduler_t*            Scheduler,
     _In_ int                        ResetElements,
     _In_ int                        ResetFramelist);
 
-__EXTERN uintptr_t
+extern uintptr_t
 UsbSchedulerGetDma(
     _In_ UsbSchedulerPool_t* schedulerPool,
     _In_ const uint8_t*      elementPointer);
 
 /* UsbSchedulerGetPoolElement
  * Retrieves the element at the given pool and index. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerGetPoolElement(
     _In_  UsbScheduler_t*           Scheduler,
     _In_  int                       Pool,
@@ -235,7 +235,7 @@ UsbSchedulerGetPoolElement(
 
 /* UsbSchedulerGetPoolFromElement
  * Retrieves which pool an element belongs to by only knowing the address. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerGetPoolFromElement(
         _In_  UsbScheduler_t*      scheduler,
         _In_  const uint8_t*       element,
@@ -245,7 +245,7 @@ UsbSchedulerGetPoolFromElement(
  * Allocates a new element for usage with the scheduler. If this returns
  * OS_EUNKNOWN we are out of elements and we should wait till next transfer. ElementOut
  * will in this case be set to USB_OUT_OF_RESOURCES. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerAllocateElement(
     _In_  UsbScheduler_t*           Scheduler,
     _In_  int                       Pool,
@@ -254,7 +254,7 @@ UsbSchedulerAllocateElement(
 /* UsbSchedulerFreeElement
  * Releases the previously allocated element by resetting it. This call automatically
  * frees any bandwidth associated with the element. */
-__EXTERN void
+extern void
 UsbSchedulerFreeElement(
     _In_ UsbScheduler_t* usbScheduler,
     _In_ uint8_t*        element);
@@ -263,7 +263,7 @@ UsbSchedulerFreeElement(
  * Allocates bandwidth for a scheduler element. The bandwidth will automatically
  * be fitted into where is best place on schedule. If there is no more room it will
  * return OS_EUNKNOWN. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerAllocateBandwidth(
     _In_ UsbScheduler_t* scheduler,
     _In_ uint8_t         interval,
@@ -278,7 +278,7 @@ UsbSchedulerAllocateBandwidth(
  * Chains up a new element to the given element chain. The root element
  * must be specified and the element to append to the chain. Also the
  * chain direction must be specified. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerChainElement(
     _In_ UsbScheduler_t*        Scheduler,
     _In_ int                    ElementRootPool,
@@ -292,7 +292,7 @@ UsbSchedulerChainElement(
  * Removes an existing element from the given element chain. The root element
  * must be specified and the element to remove from the chain. Also the
  * chain direction must be specified. */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerUnchainElement(
     _In_ UsbScheduler_t*        Scheduler,
     _In_ int                    ElementRootPool,
@@ -304,7 +304,7 @@ UsbSchedulerUnchainElement(
 /* UsbSchedulerLinkPeriodicElement
  * Queue's up a periodic/isochronous transfer. If it was not possible
  * to schedule the transfer with the requested bandwidth, it returns OS_EUNKNOWN */
-__EXTERN oserr_t
+extern oserr_t
 UsbSchedulerLinkPeriodicElement(
     _In_ UsbScheduler_t*        Scheduler,
     _In_ int                    ElementPool,
@@ -313,7 +313,7 @@ UsbSchedulerLinkPeriodicElement(
 /* UsbSchedulerUnlinkPeriodicElement
  * Removes an already queued up periodic transfer (interrupt/isoc) from the
  * controllers scheduler. */
-__EXTERN void
+extern void
 UsbSchedulerUnlinkPeriodicElement(
     _In_ UsbScheduler_t*        Scheduler,
     _In_ int                    ElementPool,

--- a/modules/serial/usb/common/transfer.c
+++ b/modules/serial/usb/common/transfer.c
@@ -177,7 +177,7 @@ USBTransferNotify(
     TRACE("USBTransferNotify(transfer=0x%" PRIxIN ")", transfer);
 
     // If user doesn't want, ignore
-    TRACE("USBTransferNotify transfer type=%u", transfer->Base.Type);
+    TRACE("USBTransferNotify transfer type=%u", transfer->Type);
     if (transfer->Flags & __USBTRANSFER_FLAG_SILENT) {
         return;
     }

--- a/modules/serial/usb/common/transfer.h
+++ b/modules/serial/usb/common/transfer.h
@@ -55,6 +55,11 @@ struct TransferElement {
         // and OHCI descritpors that do not support SG.
         uintptr_t Address;
         struct {
+            uintptr_t Page0;
+            uintptr_t Page1;
+            uint32_t  Offsets[8];
+        } OHCI;
+        struct {
             // Isoc TDs hold up to 8 transactions
             // Normal TDs hold up to 5 transactions
             uintptr_t Addresses[8];

--- a/modules/serial/usb/common/transfer.h
+++ b/modules/serial/usb/common/transfer.h
@@ -25,6 +25,10 @@
 #include <os/spinlock.h>
 #include <threads.h>
 
+#define __XPAGE(_a) ((_a) & ~((uintptr_t)0xFFF))
+#define __XPAGEOFFSET(_a) ((_a) & 0xFFF)
+#define __XUPPAGE(_a) (__XPAGE(_a) + 0x1000)
+
 #define __USBTRANSFER_FLAG_SHORT       0x1
 #define __USBTRANSFER_FLAG_NOTIFIED    0x2
 #define __USBTRANSFER_FLAG_SILENT      0x4

--- a/modules/serial/usb/common/transfer.h
+++ b/modules/serial/usb/common/transfer.h
@@ -140,20 +140,11 @@ static inline bool __Transfer_IsAsync(UsbManagerTransfer_t* transfer) {
 }
 
 /**
- * @brief Returns true if the transfer is either control or bulk
+ * @brief Returns true if the transfer is either interrupt or isoc
  */
 static inline bool __Transfer_IsPeriodic(UsbManagerTransfer_t* transfer) {
     return transfer->Type == USBTRANSFER_TYPE_INTERRUPT ||
         transfer->Type == USBTRANSFER_TYPE_ISOC;
-}
-
-/**
- * @brief Returns true if the transaction may need to have it's data toggles
- * synced in case of errors or a short transfer.
- */
-static inline bool __Transfer_MaySync(UsbManagerTransfer_t* transfer) {
-    return transfer->Type == USBTRANSFER_TYPE_BULK ||
-        transfer->Type == USBTRANSFER_TYPE_INTERRUPT;
 }
 
 /**

--- a/modules/serial/usb/ehci/ehci.h
+++ b/modules/serial/usb/ehci/ehci.h
@@ -663,10 +663,11 @@ EhciPortScan(
 extern
 oserr_t
 EHCIQHInitialize(
-    _In_ EhciController_t*     controller,
-    _In_ UsbManagerTransfer_t* transfer,
-    _In_ uint8_t               deviceAddress,
-    _In_ uint8_t               endpointAddress);
+        _In_ EhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ EhciQueueHead_t*      qh,
+        _In_ uint8_t               deviceAddress,
+        _In_ uint8_t               endpointAddress);
 
 /* EHCIQHDump
  * Dumps the information contained in the queue-head by writing it to stdout */

--- a/modules/serial/usb/ehci/structures/itd.c
+++ b/modules/serial/usb/ehci/structures/itd.c
@@ -37,7 +37,11 @@ EHCITDIsochronous(
     uintptr_t buffer      = addresses[0] & pageMask;
     uint32_t  bufferIndex = 0;
 
-    iTd->Link          = EHCI_LINK_END;
+    /**
+     * When calling these initializers for TDs, the TDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
     iTd->Object.Flags |= EHCI_LINK_iTD;
 
     // initialize the buffer special bits

--- a/modules/serial/usb/ehci/structures/qh.c
+++ b/modules/serial/usb/ehci/structures/qh.c
@@ -25,12 +25,12 @@
 
 oserr_t
 EHCIQHInitialize(
-    _In_ EhciController_t*     controller,
-    _In_ UsbManagerTransfer_t* transfer,
-    _In_ uint8_t               deviceAddress,
-    _In_ uint8_t               endpointAddress)
+        _In_ EhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ EhciQueueHead_t*      qh,
+        _In_ uint8_t               deviceAddress,
+        _In_ uint8_t               endpointAddress)
 {
-    EhciQueueHead_t* qh        = (EhciQueueHead_t*)transfer->RootElement;
     oserr_t          oserr     = OS_EOK;
 
     // Initialize links

--- a/modules/serial/usb/ehci/structures/td.c
+++ b/modules/serial/usb/ehci/structures/td.c
@@ -59,8 +59,11 @@ EHCITDSetup(
     _In_ EhciTransferDescriptor_t* td,
     _In_ uintptr_t                 dataAddress)
 {
-    // Initialize the transfer-descriptor
-    td->Link            = EHCI_LINK_END;
+    /**
+     * When calling these initializers for TDs, the TDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
     td->AlternativeLink = EHCI_LINK_END;
 
     td->Status = EHCI_TD_ACTIVE;
@@ -84,8 +87,13 @@ EHCITDData(
     _In_ size_t                    length,
     _In_ int                       toggle)
 {
+    /**
+     * When calling these initializers for TDs, the TDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
+
     // Initialize the new Td
-    td->Link   = EHCI_LINK_END;
     td->Status = EHCI_TD_ACTIVE;
     td->Token  = pid | EHCI_TD_ERRCOUNT;
 

--- a/modules/serial/usb/ehci/transfer.c
+++ b/modules/serial/usb/ehci/transfer.c
@@ -199,13 +199,14 @@ __CalculateTransferElementMetrics(
     element->Length = calculatedLength;
 }
 
-int
+oserr_t
 HCITransferElementsNeeded(
-        _In_ UsbManagerTransfer_t*     transfer,
-        _In_ uint32_t                  transferLength,
-        _In_ enum USBTransferDirection direction,
-        _In_ SHMSGTable_t*             sgTable,
-        _In_ uint32_t                  sgTableOffset)
+        _In_  UsbManagerTransfer_t*     transfer,
+        _In_  uint32_t                  transferLength,
+        _In_  enum USBTransferDirection direction,
+        _In_  SHMSGTable_t*             sgTable,
+        _In_  uint32_t                  sgTableOffset,
+        _Out_ int*                      elementCountOut)
 {
     struct TransferElement element;
     uint32_t               bytesLeft = transferLength;
@@ -250,7 +251,8 @@ HCITransferElementsNeeded(
         }
     }
     TRACE("EHCITransferElementsNeeded: %i", tdsNeeded);
-    return tdsNeeded;
+    *elementCountOut = tdsNeeded;
+    return tdsNeeded == 0 ? OS_EINVALPARAMS : OS_EOK;
 }
 
 void

--- a/modules/serial/usb/ohci/controller.c
+++ b/modules/serial/usb/ohci/controller.c
@@ -458,5 +458,5 @@ OhciSetup(
     
     // Wait for ports to power up in any case, even if power is always on/global
     thrd_sleep(&(struct timespec) { .tv_nsec = Controller->PowerOnDelayMs * NSEC_PER_MSEC }, NULL);
-    return OhciPortsCheck(Controller, 1);
+    return OHCICheckPorts(Controller, 1);
 }

--- a/modules/serial/usb/ohci/interrupts.c
+++ b/modules/serial/usb/ohci/interrupts.c
@@ -100,7 +100,7 @@ ProcessInterrupt:
     // Root Hub Status Change
     // This occurs on disconnect/connect events
     if (InterruptStatus & OHCI_ROOTHUB_EVENT) {
-        OhciPortsCheck(Controller, 0);
+        OHCICheckPorts(Controller, 0);
     }
 
     // Fatal errors, reset everything

--- a/modules/serial/usb/ohci/interrupts.c
+++ b/modules/serial/usb/ohci/interrupts.c
@@ -106,15 +106,15 @@ ProcessInterrupt:
     // Fatal errors, reset everything
     if (InterruptStatus & (OHCI_FATAL_EVENT | OHCI_OVERRUN_EVENT)) {
         OHCIQueueReset(Controller);
-        OhciReset(Controller);
-        OhciSetMode(Controller, OHCI_CONTROL_ACTIVE);
+        OHCIReset(Controller);
+        OHCISetMode(Controller, OHCI_CONTROL_ACTIVE);
     }
 
     // Resume Detection? 
     // We must wait 20 ms before putting Controller to Operational
     if (InterruptStatus & OHCI_RESUMEDETECT_EVENT) {
         thrd_sleep(&(struct timespec) { .tv_nsec = 20 * NSEC_PER_MSEC }, NULL);
-        OhciSetMode(Controller, OHCI_CONTROL_ACTIVE);
+        OHCISetMode(Controller, OHCI_CONTROL_ACTIVE);
     }
 
     // Stage 2 of an linking/unlinking event

--- a/modules/serial/usb/ohci/ohci.h
+++ b/modules/serial/usb/ohci/ohci.h
@@ -444,14 +444,6 @@ OHCITDVerify(
     _In_ struct HCIProcessReasonScanContext* scanContext,
     _In_ OhciTransferDescriptor_t*           td);
 
-/* OhciTdSynchronize
- * Synchronizes the toggle status of the transfer descriptor by retrieving
- * current and updating the pipe toggle. */
-extern void
-OhciTdSynchronize(
-    _In_ UsbManagerTransfer_t*      Transfer,
-    _In_ OhciTransferDescriptor_t*  Td);
-
 /* OHCITDRestart
  * Restarts a transfer descriptor by resettings it's status and updating buffers if the
  * trasnfer type is an interrupt-transfer that uses circularbuffers. */

--- a/modules/serial/usb/ohci/ohci.h
+++ b/modules/serial/usb/ohci/ohci.h
@@ -415,7 +415,7 @@ OHCIQHLink(
 extern void
 OHCITDSetup(
     _In_ OhciTransferDescriptor_t* td,
-    _In_ uintptr_t                 dataAddress);
+    _In_ struct TransferElement*   element);
 
 /* OHCITDData
  * Creates a new io token td and initializes all the members.
@@ -424,9 +424,8 @@ extern void
 OHCITDData(
     _In_ OhciTransferDescriptor_t*  td,
     _In_ enum USBTransferType       type,
-    _In_ uint32_t                   PID,
-    _In_ uintptr_t                  dataAddress,
-    _In_ size_t                     length,
+    _In_ uint32_t                   pid,
+    _In_ struct TransferElement*    element,
     _In_ int                        toggle);
 
 /* OHCITDDump
@@ -453,7 +452,7 @@ OHCITDRestart(
     _In_ UsbManagerTransfer_t*      transfer,
     _In_ OhciTransferDescriptor_t*  td);
 
-/*******************************************************************************
+/******************************************************************************
  * Isochronous Transfer Descriptor Methods
  *******************************************************************************/
 
@@ -462,11 +461,10 @@ OHCITDRestart(
  * The Td is immediately ready for execution. */
 extern void
 OHCITDIsochronous(
-    _In_ OhciIsocTransferDescriptor_t*  Td,
-    _In_ size_t                         MaxPacketSize,
-    _In_ uint32_t                       PId,
-    _In_ uintptr_t                      Address,
-    _In_ size_t                         Length);
+    _In_ OhciIsocTransferDescriptor_t* td,
+    _In_ size_t                        maxPacketSize,
+    _In_ uint32_t                      pid,
+    _In_ struct TransferElement*       element);
 
 /* OHCIITDDump
  * Dumps the information contained in the descriptor by writing it. */

--- a/modules/serial/usb/ohci/ohci.h
+++ b/modules/serial/usb/ohci/ohci.h
@@ -95,7 +95,8 @@ PACKED_TYPESTRUCT(OhciTransferDescriptor, {
     reg32_t                 OriginalCbp;        // Copy of buffer
 });
 
-/* OhciTransferDescriptor::Flags & OhciIsocTransferDescriptor::Flags
+/**
+ * OhciTransferDescriptor::Flags & OhciIsocTransferDescriptor::Flags
  * Contains definitions and bitfield definitions for OhciTransferDescriptor::Flags
  * Bits 0-17:  Available
  * Bits 18:    If 0, Requires the data to be recieved from an endpoint to exactly fill buffer
@@ -103,7 +104,8 @@ PACKED_TYPESTRUCT(OhciTransferDescriptor, {
  * Bits 21-23: Interrupt delay count for this TD. This means the HC can delay interrupt a specific amount of frames after TD completion.
  * Bits 24-25: Data Toggle. It is updated after each successful transmission.
  * Bits 26-27: Error Count. Updated each transmission that fails. It is 0 on success.
- * Bits 28-31: Condition Code, if error count is 2 and it fails a third time, this contains error code. */
+ * Bits 28-31: Condition Code, if error count is 2 and it fails a third time, this contains error code.
+ */
 #define OHCI_TD_SHORTPACKET_OK          (1 << 18)
 #define OHCI_TD_SETUP                   0
 #define OHCI_TD_OUT                     (1 << 19)
@@ -334,10 +336,10 @@ __EXTERN oserr_t
 OhciQueueDestroy(
     _In_ OhciController_t*  Controller);
 
-/* OhciPortsCheck
+/* OHCICheckPorts
  * Enumerates all the ports and detects for connection/error events */
 __EXTERN oserr_t
-OhciPortsCheck(
+OHCICheckPorts(
     _In_ OhciController_t* Controller,
     _In_ int               IgnorePowerOn);
 
@@ -357,10 +359,9 @@ OhciSetMode(
  * hcd flags. Afterwards the queue head is ready for use. */
 __EXTERN oserr_t
 OHCIQHInitialize(
-    _In_ OhciController_t*      controller,
-    _In_ UsbManagerTransfer_t*  transfer,
-    _In_ size_t                 address,
-    _In_ size_t                 endpoint);
+        _In_ OhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ OhciQueueHead_t*      qh);
 
 /* OHCIQHDump
  * Dumps the information contained in the queue-head by writing it to stdout */

--- a/modules/serial/usb/ohci/ohci.yaml
+++ b/modules/serial/usb/ohci/ohci.yaml
@@ -3,3 +3,6 @@ driver:
   type:
     - class: 0xC0003
     - subclass: 0x100000
+# depends:
+#   services:
+#     - usbd

--- a/modules/serial/usb/ohci/queue.c
+++ b/modules/serial/usb/ohci/queue.c
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define __TRACE
+//#define __TRACE
 
 #include <assert.h>
 #include <ddk/utils.h>
@@ -98,7 +98,7 @@ OHCIQueueInitialize(
 
     TRACE("OHCIQueueInitialize()");
 
-    TRACE(" > Configuring scheduler");
+    TRACE("OHCIQueueInitialize: configurating scheduler settings");
     UsbSchedulerSettingsCreate(&Settings, OHCI_FRAMELIST_SIZE, 1, 900, USB_SCHEDULER_NULL_ELEMENT);
 
     UsbSchedulerSettingsConfigureFrameList(&Settings, (reg32_t*)&Controller->Hcca->InterruptTable[0],
@@ -117,7 +117,7 @@ OHCIQueueInitialize(
         offsetof(OhciIsocTransferDescriptor_t, Link), offsetof(OhciIsocTransferDescriptor_t, Object));
     
     // Create the scheduler
-    TRACE(" > Initializing scheduler");
+    TRACE("OHCIQueueInitialize: initializing scheduler");
     UsbSchedulerInitialize(&Settings, &Controller->Base.Scheduler);
 
     // Initialize internal data structures
@@ -177,7 +177,7 @@ HCIProcessElement(
     _In_ enum HCIProcessReason   reason,
     _In_ void*                   context)
 {
-    TRACE("OhciProcessElement(reason=%i)", reason);
+    TRACE("OHCIProcessElement(reason=%i)", reason);
 
     // Handle the reasons
     switch (reason) {

--- a/modules/serial/usb/ohci/queue.c
+++ b/modules/serial/usb/ohci/queue.c
@@ -130,20 +130,19 @@ OHCIQueueReset(
 {
     TRACE("OHCIQueueReset()");
 
-    OhciSetMode(controller, OHCI_CONTROL_SUSPEND);
+    OHCISetMode(controller, OHCI_CONTROL_SUSPEND);
     UsbManagerClearTransfers(&controller->Base);
     return __ResetInternalData(controller);
 }
 
-oserr_t
-OhciQueueDestroy(
+void
+OHCIQueueDestroy(
     _In_ OhciController_t* Controller)
 {
-    TRACE("OhciQueueDestroy()");
+    TRACE("OHCIQueueDestroy()");
 
     OHCIQueueReset(Controller);
     UsbSchedulerDestroy(Controller->Base.Scheduler);
-    return OS_EOK;
 }
 
 enum USBTransferCode

--- a/modules/serial/usb/ohci/structures/itd.c
+++ b/modules/serial/usb/ohci/structures/itd.c
@@ -1,7 +1,5 @@
 /**
- * MollenOS
- *
- * Copyright 2018, Philip Meulengracht
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,12 +13,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- *
- * Open Host Controller Interface Driver
- * TODO:
- *    - Power Management
  */
+
 //#define __TRACE
 #define __need_minmax
 #include <os/mollenos.h>
@@ -83,8 +77,11 @@ OHCITDIsochronous(
         FrameIndex++;
     }
 
-    // Set this is as end of chain
-    Td->Link = 0;
+    /**
+     * When calling these initializers for ITDs, the ITDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
 
     // Store copy of original content
     Td->OriginalFlags     = Td->Flags;

--- a/modules/serial/usb/ohci/structures/itd.c
+++ b/modules/serial/usb/ohci/structures/itd.c
@@ -49,7 +49,7 @@ OHCITDIsochronous(
     iTd->Flags |= OHCI_TD_ACTIVE;
 
     iTd->Cbp       = element->Data.OHCI.Page0;
-    iTd->BufferEnd = element->Data.OHCI.Page1 + element->Data.OHCI.Offsets[frameCount - 1];
+    iTd->BufferEnd = element->Data.OHCI.Page1;
     for (int i = 0; i < frameCount; i++) {
         iTd->Offsets[i] = element->Data.OHCI.Offsets[i];
         iTd->OriginalOffsets[i] = element->Data.OHCI.Offsets[i];

--- a/modules/serial/usb/ohci/structures/qh.c
+++ b/modules/serial/usb/ohci/structures/qh.c
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 //#define __TRACE
 
 #include <os/mollenos.h>
@@ -34,15 +35,14 @@ __GetNullIndex(
 
 oserr_t
 OHCIQHInitialize(
-    _In_ OhciController_t*      controller,
-    _In_ UsbManagerTransfer_t*  transfer,
-    _In_ size_t                 address,
-    _In_ size_t                 endpoint)
+        _In_ OhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ OhciQueueHead_t*      qh)
 {
-    OhciQueueHead_t* qh        = transfer->RootElement;
-    uint16_t         lastIndex = __GetNullIndex(transfer);
-    uintptr_t        linkEnd;
-    oserr_t          oserr;
+    uint16_t  lastIndex = __GetNullIndex(transfer);
+    uintptr_t linkEnd;
+    oserr_t   oserr;
+    TRACE("OHCIQHInitialize()");
 
     oserr = UsbSchedulerGetPoolElement(
             controller->Base.Scheduler,
@@ -60,8 +60,8 @@ OHCIQHInitialize(
     qh->EndPointer        = (reg32_t)linkEnd;
     qh->Object.DepthIndex = lastIndex;
 
-    qh->Flags = OHCI_QH_ADDRESS(address);
-    qh->Flags |= OHCI_QH_ENDPOINT(endpoint);
+    qh->Flags = OHCI_QH_ADDRESS(transfer->Address.DeviceAddress);
+    qh->Flags |= OHCI_QH_ENDPOINT(transfer->Address.EndpointAddress);
     qh->Flags |= OHCI_QH_DIRECTIONTD; // Retrieve from TD
     qh->Flags |= OHCI_QH_LENGTH(transfer->MaxPacketSize);
     qh->Flags |= OHCI_QH_TYPE(transfer->Type);

--- a/modules/serial/usb/ohci/transfer.c
+++ b/modules/serial/usb/ohci/transfer.c
@@ -105,38 +105,38 @@ HCITransferFinalize(
     // reload the asynchronous queue
     if (__Transfer_IsAsync(transfer)) {
         // Check if the link of the QH is eol
-        reg32_t Status  = READ_VOLATILE(ohciController->Registers->HcCommandStatus);
-        reg32_t Control = ohciController->QueuesActive;
-        if ((Status & OHCI_COMMAND_CONTROL_FILLED) == 0) {
+        reg32_t status  = READ_VOLATILE(ohciController->Registers->HcCommandStatus);
+        reg32_t control = ohciController->QueuesActive;
+        if ((status & OHCI_COMMAND_CONTROL_FILLED) == 0) {
             if (ohciController->TransactionsWaitingControl != 0) {
                 // Conditions for control fulfilled
                 OHCIReloadAsynchronous(ohciController, USBTRANSFER_TYPE_CONTROL);
-                Status  |= OHCI_COMMAND_CONTROL_FILLED;
-                Control |= OHCI_CONTROL_CONTROL_ACTIVE;
+                status  |= OHCI_COMMAND_CONTROL_FILLED;
+                control |= OHCI_CONTROL_CONTROL_ACTIVE;
             }
             else {
                 if (READ_VOLATILE(ohciController->Registers->HcControlHeadED) == 0) {
-                    Control &= ~(OHCI_CONTROL_CONTROL_ACTIVE);
+                    control &= ~(OHCI_CONTROL_CONTROL_ACTIVE);
                 }
             }
         }
-        if ((Status & OHCI_COMMAND_BULK_FILLED) == 0) {
+        if ((status & OHCI_COMMAND_BULK_FILLED) == 0) {
             if (ohciController->TransactionsWaitingBulk != 0) {
                 // Conditions for bulk fulfilled
                 OHCIReloadAsynchronous(ohciController, USBTRANSFER_TYPE_BULK);
-                Status  |= OHCI_COMMAND_BULK_FILLED;
-                Control |= OHCI_CONTROL_BULK_ACTIVE;
+                status  |= OHCI_COMMAND_BULK_FILLED;
+                control |= OHCI_CONTROL_BULK_ACTIVE;
             }
             else {
                 if (READ_VOLATILE(ohciController->Registers->HcBulkHeadED) == 0) {
-                    Control &= ~(OHCI_CONTROL_BULK_ACTIVE);
+                    control &= ~(OHCI_CONTROL_BULK_ACTIVE);
                 }
             }
         }
 
         // Update
-        WRITE_VOLATILE(ohciController->Registers->HcCommandStatus, Status);
-        ohciController->QueuesActive = Control;
+        WRITE_VOLATILE(ohciController->Registers->HcCommandStatus, status);
+        ohciController->QueuesActive = control;
     }
 
     // Don't unlink asynchronous transfers
@@ -202,8 +202,8 @@ __CalculateTransferElementMetrics(
         _Out_ uintptr_t*           dataAddressOut,
         _Out_ uint32_t*            lengthOut)
 {
-    int       index;
-    size_t    offset;
+    int    index;
+    size_t offset;
     TRACE("__CalculateTransferElementMetrics(offset=%u, mps=%u, len=%u)",
           sgTableOffset, (uint32_t)maxPacketSize, transferLength);
 

--- a/modules/serial/usb/uhci/controller.c
+++ b/modules/serial/usb/uhci/controller.c
@@ -303,8 +303,11 @@ UhciSetup(
     }
 
     // Set up the i/o requirements, UHCI controllers sometimes have problems
-    // with addresses above >2gb.
-    controller->Base.IORequirements.BufferAlignment = 0;
+    // with addresses above >2gb. Also buffer alignment must be used for UHCI as
+    // we cannot deal with cross-page boundary buffers. Thus buffers must be aligned
+    // for the highest possible packet-size supported by USB 1.1.
+    // Maximum data payload size for full-speed devices is 64 bytes.
+    controller->Base.IORequirements.BufferAlignment = 64;
     controller->Base.IORequirements.Conformity = OSMEMORYCONFORMITY_LOW;
 
     oserr = UhciReset(controller);

--- a/modules/serial/usb/uhci/structures/qh.c
+++ b/modules/serial/usb/uhci/structures/qh.c
@@ -47,11 +47,10 @@ __CalculateFrameQueue(
 
 oserr_t
 UHCIQHInitialize(
-    _In_ UhciController_t*     controller,
-    _In_ UsbManagerTransfer_t* transfer)
+        _In_ UhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ UhciQueueHead_t*       queueHead)
 {
-    UhciQueueHead_t* queueHead = transfer->RootElement;
-
     queueHead->Link  = UHCI_LINK_END;
     queueHead->Child = UHCI_LINK_END;
     queueHead->Object.Flags |= UHCI_LINK_QH;

--- a/modules/serial/usb/uhci/structures/td.c
+++ b/modules/serial/usb/uhci/structures/td.c
@@ -28,7 +28,11 @@ UHCITDSetup(
         _In_ enum USBSpeed             speed,
         _In_ uintptr_t                 address)
 {
-    td->Link = UHCI_LINK_END;
+    /**
+     * When calling these initializers for TDs, the TDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
 
     td->Flags  = UHCI_TD_ACTIVE;
     td->Flags |= UHCI_TD_SETCOUNT(3);
@@ -64,8 +68,11 @@ UHCITDData(
     _In_ uint32_t                  length,
     _In_ int                       toggle)
 {
-    // Set no link
-    td->Link = UHCI_LINK_END;
+    /**
+     * When calling these initializers for TDs, the TDs have already been
+     * correctly linked, and their links set accordingly. So we do not touch
+     * the links, unless they need a specific hardcoded value.
+     */
 
     // Setup td flags
     td->Flags  = UHCI_TD_ACTIVE;

--- a/modules/serial/usb/uhci/uhci.h
+++ b/modules/serial/usb/uhci/uhci.h
@@ -114,6 +114,7 @@ PACKED_TYPESTRUCT(UhciTransferDescriptor, {
 /* UhciTransferDescriptor::Flags
  * Contains definitions and bitfield definitions for UhciTransferDescriptor::Flags */
 #define UHCI_TD_LENGTH_MASK             0x7FF
+#define UHCI_TD_MAXLENGTH               0x4FF
 #define UHCI_TD_ACTIVE                  (1 << 23)
 #define UHCI_TD_IOC                     (1 << 24)
 #define UHCI_TD_ISOCHRONOUS             (1 << 25)
@@ -311,8 +312,9 @@ UhciConditionCodeToIndex(
  */
 extern oserr_t
 UHCIQHInitialize(
-    _In_ UhciController_t*     controller,
-    _In_ UsbManagerTransfer_t* transfer);
+        _In_ UhciController_t*     controller,
+        _In_ UsbManagerTransfer_t* transfer,
+        _In_ UhciQueueHead_t*       queueHead);
 
 /* UHCIQHDump
  * Dumps the information contained in the queue-head by writing it to stdout */

--- a/modules/storage/ahci/manager.c
+++ b/modules/storage/ahci/manager.c
@@ -229,8 +229,8 @@ AhciManagerUnregisterDevice(
         }
     }
     assert(device != NULL);
-    
-    UnregisterStorage(device->Descriptor.DeviceID, 1);
+
+    __UnregisterStorage(device->Descriptor.DeviceID, 1);
     list_remove(&devices, &device->header);
 }
 
@@ -297,7 +297,7 @@ HandleIdentifyCommand(
     // Copy string data
     memcpy(&device->Descriptor.Model[0], (const void*)&deviceInformation->ModelNo[0], 40);
     memcpy(&device->Descriptor.Serial[0], (const void*)&deviceInformation->SerialNo[0], 20);
-    RegisterStorage(GetNativeHandle(__crt_get_server_iod()), device->Descriptor.DeviceID, device->Descriptor.Flags);
+    __RegisterStorage(GetNativeHandle(__crt_get_server_iod()), device->Descriptor.DeviceID, device->Descriptor.Flags);
 }
 
 void

--- a/modules/storage/ahci/manager.c
+++ b/modules/storage/ahci/manager.c
@@ -1,6 +1,4 @@
 /**
- * MollenOS
- *
  * Copyright 2017, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
@@ -185,7 +183,7 @@ AhciManagerRegisterDevice(
 }
 
 static void
-RegisterStorage(
+__RegisterStorage(
         _In_ uuid_t       ProtocolServerId,
         _In_ uuid_t       DeviceId,
         _In_ unsigned int Flags)
@@ -200,7 +198,7 @@ RegisterStorage(
 }
 
 static void
-UnregisterStorage(
+__UnregisterStorage(
         _In_ uuid_t  deviceId,
         _In_ uint8_t forced)
 {

--- a/modules/storage/msd/main.c
+++ b/modules/storage/msd/main.c
@@ -35,7 +35,7 @@ extern gracht_server_t* __crt_get_module_server(void);
 
 static list_t g_devices = LIST_INIT;
 
-MsdDevice_t*
+MSDDevice_t*
 MsdDeviceGet(
         _In_ uuid_t deviceId)
 {
@@ -56,7 +56,7 @@ DestroyElement(
     _In_ element_t* Element,
     _In_ void*      Context)
 {
-    MsdDeviceDestroy(Element->value);
+    MSDDeviceDestroy(Element->value);
 }
 
 void
@@ -74,9 +74,9 @@ oserr_t OnEvent(struct ioset_event* event)
 void ctt_driver_register_device_invocation(struct gracht_message* message, const struct sys_device* device)
 {
     UsbDevice_t* usbDevice = (UsbDevice_t*)from_sys_device(device);
-    MsdDevice_t* msdDevice;
+    MSDDevice_t* msdDevice;
 
-    msdDevice = MsdDeviceCreate(usbDevice);
+    msdDevice = MSDDeviceCreate(usbDevice);
     if (msdDevice == NULL) {
         ERROR("OnRegister failed to create MSD device");
         return;
@@ -88,20 +88,20 @@ oserr_t
 OnUnregister(
     _In_ Device_t *Device)
 {
-    MsdDevice_t* MsdDevice = MsdDeviceGet(Device->Id);
+    MSDDevice_t* MsdDevice = MsdDeviceGet(Device->Id);
     if (MsdDevice == NULL) {
         return OS_EUNKNOWN;
     }
 
     list_remove(&g_devices, &MsdDevice->Header);
-    return MsdDeviceDestroy(MsdDevice);
+    return MSDDeviceDestroy(MsdDevice);
 }
 
 void ctt_storage_stat_invocation(struct gracht_message* message, const uuid_t deviceId)
 {
     struct sys_disk_descriptor gdescriptor = { 0 };
     oserr_t                    oserr      = OS_ENOENT;
-    MsdDevice_t*               device     = MsdDeviceGet(deviceId);
+    MSDDevice_t*               device     = MsdDeviceGet(deviceId);
     TRACE("[msd] [stat]");
     
     if (device) {
@@ -123,7 +123,7 @@ void ctt_driver_ioctl_invocation(
         _In_ const uint32_t         out_count)
 {
     enum OSIOCtlRequest req = (enum OSIOCtlRequest)request;
-    MsdDevice_t*        device = MsdDeviceGet(deviceId);
+    MSDDevice_t*        device = MsdDeviceGet(deviceId);
     oserr_t             oserr;
     if (device == NULL) {
         ctt_driver_ioctl_response(message, NULL, 0, OS_ENOENT);
@@ -135,13 +135,9 @@ void ctt_driver_ioctl_invocation(
             // MSD driver does not pose any memory conformity requirements
             // on its I/O requests. So we report the controller requirements
             // instead
-            struct OSIOCtlRequestRequirements ioRequirements= {
-                    .BufferAlignment = 0,
-                    .Conformity = device->Conformity
-            };
             ctt_driver_ioctl_response(
                     message,
-                    (uint8_t*)&ioRequirements,
+                    (uint8_t*)&device->IORequirements,
                     sizeof(struct OSIOCtlRequestRequirements),
                     OS_EOK
             );

--- a/modules/storage/msd/main.c
+++ b/modules/storage/msd/main.c
@@ -133,21 +133,17 @@ void ctt_driver_ioctl_invocation(
     switch (req) {
         case OSIOCTLREQUEST_IO_REQUIREMENTS: {
             // MSD driver does not pose any memory conformity requirements
-            // on its I/O requests. So we need to query the controller itself
-            // for this.
-            struct OSIOCtlRequestRequirements ioRequirements;
-            oserr = OSDeviceIOCtl2(
-                    device->Device->DeviceContext.controller_device_id,
-                    device->Device->DeviceContext.controller_driver_id,
-                    req,
-                    &ioRequirements,
-                    sizeof(struct OSIOCtlRequestRequirements)
-            );
+            // on its I/O requests. So we report the controller requirements
+            // instead
+            struct OSIOCtlRequestRequirements ioRequirements= {
+                    .BufferAlignment = 0,
+                    .Conformity = device->Conformity
+            };
             ctt_driver_ioctl_response(
                     message,
                     (uint8_t*)&ioRequirements,
                     sizeof(struct OSIOCtlRequestRequirements),
-                    oserr
+                    OS_EOK
             );
             return;
         }

--- a/modules/storage/msd/msd.h
+++ b/modules/storage/msd/msd.h
@@ -24,6 +24,7 @@
 #define _USB_MSD_H_
 
 #include <os/osdefs.h>
+#include <os/types/device.h>
 #include "../scsi/scsi.h"
 #include <ds/list.h>
 
@@ -122,20 +123,21 @@ typedef enum MsdProtocolType {
 
 typedef struct MsdDevice MsdDevice_t;
 typedef struct MsdOperations {
-    oserr_t          (*Initialize)(MsdDevice_t*);
-    enum USBTransferCode (*SendCommand)(MsdDevice_t*, uint8_t, uint64_t, uuid_t, size_t, size_t);
-    enum USBTransferCode (*ReadData)(MsdDevice_t*, uuid_t, size_t, size_t, size_t*);
-    enum USBTransferCode (*WriteData)(MsdDevice_t*, uuid_t, size_t, size_t, size_t*);
-    enum USBTransferCode (*GetStatus)(MsdDevice_t*);
+    oserr_t (*Initialize)(MsdDevice_t*);
+    oserr_t (*SendCommand)(MsdDevice_t*, uint8_t, uint64_t, size_t, enum USBTransferCode*);
+    oserr_t (*ReadData)(MsdDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
+    oserr_t (*WriteData)(MsdDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
+    oserr_t (*GetStatus)(MsdDevice_t*, enum USBTransferCode*);
 } MsdOperations_t;
 
 typedef struct MsdDevice {
-    UsbDevice_t*           Device;
-    element_t              Header;
-    StorageDescriptor_t    Descriptor;
-    MsdDeviceType_t        Type;
-    MsdProtocolType_t      Protocol;
-    const MsdOperations_t* Operations;
+    UsbDevice_t*            Device;
+    element_t               Header;
+    StorageDescriptor_t     Descriptor;
+    MsdDeviceType_t         Type;
+    MsdProtocolType_t       Protocol;
+    const MsdOperations_t*  Operations;
+    enum OSMemoryConformity Conformity;
 
 	int IsReady;
 	int IsExtended;

--- a/modules/storage/msd/msd.h
+++ b/modules/storage/msd/msd.h
@@ -1,7 +1,5 @@
-/** 
- * MollenOS
- *
- * Copyright 2017, Philip Meulengracht
+/**
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -121,23 +119,26 @@ typedef enum MsdProtocolType {
     ProtocolCount
 } MsdProtocolType_t;
 
-typedef struct MsdDevice MsdDevice_t;
-typedef struct MsdOperations {
-    oserr_t (*Initialize)(MsdDevice_t*);
-    oserr_t (*SendCommand)(MsdDevice_t*, uint8_t, uint64_t, size_t, enum USBTransferCode*);
-    oserr_t (*ReadData)(MsdDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
-    oserr_t (*WriteData)(MsdDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
-    oserr_t (*GetStatus)(MsdDevice_t*, enum USBTransferCode*);
-} MsdOperations_t;
+typedef struct MSDDevice MSDDevice_t;
+typedef struct MSDOperations {
+    oserr_t (*Initialize)(MSDDevice_t*);
+    oserr_t (*SendCommand)(MSDDevice_t*, uint8_t, uint64_t, size_t, enum USBTransferCode*);
+    oserr_t (*ReadData)(MSDDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
+    oserr_t (*WriteData)(MSDDevice_t*, uuid_t, size_t, size_t, enum USBTransferCode*, size_t*);
+    oserr_t (*GetStatus)(MSDDevice_t*, enum USBTransferCode*);
+} MSDOperations_t;
 
-typedef struct MsdDevice {
+typedef struct MSDDevice {
     UsbDevice_t*            Device;
     element_t               Header;
     StorageDescriptor_t     Descriptor;
     MsdDeviceType_t         Type;
     MsdProtocolType_t       Protocol;
-    const MsdOperations_t*  Operations;
-    enum OSMemoryConformity Conformity;
+    const MSDOperations_t*  Operations;
+
+    // To avoid retrieving it from the underlying controller
+    // all the time. Cache it here for convenience.
+    struct OSIOCtlRequestRequirements IORequirements;
 
 	int IsReady;
 	int IsExtended;
@@ -151,36 +152,37 @@ typedef struct MsdDevice {
     usb_endpoint_descriptor_t* In;
 	usb_endpoint_descriptor_t* Out;
 	usb_endpoint_descriptor_t* Interrupt;
-} MsdDevice_t;
+} MSDDevice_t;
 
-/* MsdDeviceCreate
+/* MSDDeviceCreate
  * Initializes a new msd-device from the given usb-device */
-__EXTERN MsdDevice_t*
-MsdDeviceCreate(
+extern MSDDevice_t*
+MSDDeviceCreate(
     _In_ UsbDevice_t *usbDevice);
 
-/* MsdDeviceDestroy
+/* MSDDeviceDestroy
  * Destroys an existing msd device instance and cleans up
  * any resources related to it */
-__EXTERN oserr_t
-MsdDeviceDestroy(
-    _In_ MsdDevice_t *msdDevice);
+extern oserr_t
+MSDDeviceDestroy(
+        _In_ MSDDevice_t *msdDevice);
 
-/* MsdDeviceInitialize 
+/* MSDDeviceInitialize
  * Initializes and validates that the protocol has all neccessary
  * resources/endpoints/prerequisites for operation. */
-__EXTERN oserr_t
-MsdDeviceInitialize(
-    _In_ MsdDevice_t *Device);
+extern oserr_t
+MSDDeviceInitialize(
+        _In_ MSDDevice_t *device);
 
-/* MsdDeviceStart
+/* MSDDeviceStart
  * Initializes the device by performing one-time setup and reading device
  * capabilities and features. */
-__EXTERN oserr_t
-MsdDeviceStart(
-    _In_ MsdDevice_t *device);
+extern oserr_t
+MSDDeviceStart(
+        _In_ MSDDevice_t *device);
 
-__EXTERN MsdDevice_t*
+extern MSDDevice_t*
 MsdDeviceGet(
         _In_ uuid_t deviceId);
+
 #endif // !_USB_MSD_H_

--- a/modules/storage/msd/protocols/bulk.c
+++ b/modules/storage/msd/protocols/bulk.c
@@ -1,7 +1,5 @@
 /**
- * MollenOS
- *
- * Copyright 2017, Philip Meulengracht
+ * Copyright 2023, Philip Meulengracht
  *
  * This program is free software : you can redistribute it and / or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +18,8 @@
  * Mass Storage Device Driver (Generic)
  *  - Bulk Protocol Implementation
  */
-//#define __TRACE
+
+#define __TRACE
 
 #define BULK_RESET      0x1
 #define BULK_RESET_IN   0x2
@@ -31,331 +30,338 @@
 #include <ddk/utils.h>
 #include "../msd.h"
 
-oserr_t
-BulkReset(
-    _In_ MsdDevice_t *Device)
+static oserr_t
+__ResetBulk(
+    _In_ MsdDevice_t* device)
 {
-    enum USBTransferCode Status     = USBTRANSFERCODE_NAK;
-    int                 Iterations = 0;
+    enum USBTransferCode code  = USBTRANSFERCODE_NAK;
+    int                  tries = 0;
 
     // Reset is 
     // 0x21 | 0xFF | wIndex - Interface
-    while (Status == USBTRANSFERCODE_NAK) {
-        Status = UsbExecutePacket(&Device->Device->DeviceContext,
-            USBPACKET_DIRECTION_CLASS | USBPACKET_DIRECTION_INTERFACE,
-            MSD_REQUEST_RESET, 0, 0, (uint16_t)Device->InterfaceId, 0, NULL);
-        Iterations++;
+    while (code == USBTRANSFERCODE_NAK) {
+        code = UsbExecutePacket(
+                &device->Device->DeviceContext,
+                USBPACKET_DIRECTION_CLASS | USBPACKET_DIRECTION_INTERFACE,
+                MSD_REQUEST_RESET,
+                0, 0,
+                (uint16_t)device->InterfaceId,
+                0,
+                NULL
+        );
+        tries++;
     }
 
-    TRACE("Reset done after %i iterations", Iterations);
-    if (Status != USBTRANSFERCODE_SUCCESS) {
-        ERROR("Reset bulk returned error %u", Status);
+    TRACE("__ResetBulk: done after %i iterations", tries);
+    if (code != USBTRANSFERCODE_SUCCESS) {
+        ERROR("__ResetBulk: failed to reset interface: %u", code);
         return OS_EUNKNOWN;
     }
-    else {
-        return OS_EOK;
-    }
+    return OS_EOK;
 }
 
 static oserr_t
-ClearAndResetEndpoint(
+__ClearAndResetEndpoint(
     _In_ MsdDevice_t*               device,
     _In_ usb_endpoint_descriptor_t* endpoint)
 {
-    enum USBTransferCode status = UsbClearFeature(&device->Device->DeviceContext,
-        USBPACKET_DIRECTION_ENDPOINT, USB_ENDPOINT_ADDRESS(endpoint->Address), 
-        USB_FEATURE_HALT);
+    enum USBTransferCode status = UsbClearFeature(
+            &device->Device->DeviceContext,
+            USBPACKET_DIRECTION_ENDPOINT,
+            USB_ENDPOINT_ADDRESS(endpoint->Address),
+            USB_FEATURE_HALT
+    );
     if (status != USBTRANSFERCODE_SUCCESS) {
+        ERROR("__ClearAndResetEndpoint: failed to clear HALT: %u", status);
         return OS_EUNKNOWN;
     }
     
-    return UsbEndpointReset(&device->Device->DeviceContext,
-        USB_ENDPOINT_ADDRESS(endpoint->Address));
+    return UsbEndpointReset(
+            &device->Device->DeviceContext,
+            USB_ENDPOINT_ADDRESS(endpoint->Address)
+    );
 }
 
-oserr_t
-BulkResetRecovery(
+static oserr_t
+__ResetRecovery(
     _In_ MsdDevice_t* device,
     _In_ int          resetType)
 {
-    oserr_t status;
-    
-    // Debug
-    TRACE("MsdRecoveryReset(Type %i)", resetType);
+    oserr_t oserr = OS_EOK;
+    TRACE("__ResetRecovery(type=%i)", resetType);
 
     // Perform an initial reset
     if (resetType & BULK_RESET) {
-        status = BulkReset(device);
-        if (status != OS_EOK) {
-            ERROR("Failed to reset bulk interface");
-            return OS_EUNKNOWN;
+        oserr = __ResetBulk(device);
+        if (oserr != OS_EOK) {
+            ERROR("__ResetRecovery: failed to reset bulk interface: %u", oserr);
+            return oserr;
         }
     }
 
     // Clear HALT/STALL features on both in and out endpoints
     if (resetType & BULK_RESET_IN) {
-        status = ClearAndResetEndpoint(device, device->In);
-        if (status != OS_EOK) {
-            ERROR("Failed to clear STALL on endpoint (in)");
-            return status;
+        oserr = __ClearAndResetEndpoint(device, device->In);
+        if (oserr != OS_EOK) {
+            ERROR("__ResetRecovery: failed to clear STALL on endpoint (in)");
+            return oserr;
         }
     }
     
     if (resetType & BULK_RESET_OUT) {
-        status = ClearAndResetEndpoint(device, device->Out);
-        if (status != OS_EOK) {
-            ERROR("Failed to clear STALL on endpoint (out)");
-            return status;
+        oserr = __ClearAndResetEndpoint(device, device->Out);
+        if (oserr != OS_EOK) {
+            ERROR("__ResetRecovery: failed to clear STALL on endpoint (out)");
+            return oserr;
         }
     }
-    return status;
+    return oserr;
 }
 
-void
-BulkScsiCommandConstruct(
-    _InOut_ MsdCommandBlock_t *CmdBlock,
-    _In_ uint8_t ScsiCommand,
-    _In_ uint64_t SectorLBA,
-    _In_ uint32_t DataLen,
-    _In_ uint16_t SectorSize)
+static void
+__ConstructSCSICommand(
+    _In_ MsdCommandBlock_t* commandBlock,
+    _In_ uint8_t            scsiCommand,
+    _In_ uint64_t           sectorLba,
+    _In_ uint32_t           dataLen,
+    _In_ uint16_t           sectorSize)
 {
-    // Reset structure
-    memset((void*)CmdBlock, 0, sizeof(MsdCommandBlock_t));
-
-    // Set initial members
-    CmdBlock->Signature = MSD_CBW_SIGNATURE;
-    CmdBlock->Tag = MSD_TAG_SIGNATURE | ScsiCommand;
-    CmdBlock->CommandBytes[0] = ScsiCommand;
-    CmdBlock->DataLength = DataLen;
+    memset((void*)commandBlock, 0, sizeof(MsdCommandBlock_t));
+    commandBlock->Signature = MSD_CBW_SIGNATURE;
+    commandBlock->Tag       = MSD_TAG_SIGNATURE | scsiCommand;
+    commandBlock->CommandBytes[0] = scsiCommand;
+    commandBlock->DataLength = dataLen;
 
     // Switch between supported/implemented commands
-    switch (ScsiCommand) {
+    switch (scsiCommand) {
         // Test Unit Ready - 6 (OUT)
         case SCSI_TEST_UNIT_READY: {
-            CmdBlock->Flags = MSD_CBW_OUT;
-            CmdBlock->Length = 6;
+            commandBlock->Flags  = MSD_CBW_OUT;
+            commandBlock->Length = 6;
         } break;
 
         // Request Sense - 6 (IN)
         case SCSI_REQUEST_SENSE: {
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 6;
-            CmdBlock->CommandBytes[4] = 18; // Response length
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 6;
+            commandBlock->CommandBytes[4] = 18; // Response length
         } break;
 
         // Inquiry - 6 (IN)
         case SCSI_INQUIRY: {
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 6;
-            CmdBlock->CommandBytes[4] = 36; // Response length
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 6;
+            commandBlock->CommandBytes[4] = 36; // Response length
         } break;
 
         // Read Capacities - 10 (IN)
         case SCSI_READ_CAPACITY: {
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 10;
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 10;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[5] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[5] = (sectorLba & 0xFF);
         } break;
 
         // Read Capacities - 16 (IN)
         case SCSI_READ_CAPACITY_16: {
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 16;
-            CmdBlock->CommandBytes[1] = 0x10; // Service Action
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 16;
+            commandBlock->CommandBytes[1] = 0x10; // Service Action
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 56) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 48) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 40) & 0xFF);
-            CmdBlock->CommandBytes[5] = ((SectorLBA >> 32) & 0xFF);
-            CmdBlock->CommandBytes[6] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[7] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[8] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[9] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 56) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 48) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 40) & 0xFF);
+            commandBlock->CommandBytes[5] = ((sectorLba >> 32) & 0xFF);
+            commandBlock->CommandBytes[6] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[7] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[8] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[9] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[10] = ((DataLen >> 24) & 0xFF);
-            CmdBlock->CommandBytes[11] = ((DataLen >> 16) & 0xFF);
-            CmdBlock->CommandBytes[12] = ((DataLen >> 8) & 0xFF);
-            CmdBlock->CommandBytes[13] = (DataLen & 0xFF);
+            commandBlock->CommandBytes[10] = ((dataLen >> 24) & 0xFF);
+            commandBlock->CommandBytes[11] = ((dataLen >> 16) & 0xFF);
+            commandBlock->CommandBytes[12] = ((dataLen >> 8) & 0xFF);
+            commandBlock->CommandBytes[13] = (dataLen & 0xFF);
         } break;
 
         // Read - 6 (IN)
         case SCSI_READ_6: {
-            uint8_t NumSectors = (uint8_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint8_t NumSectors = (uint8_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 6;
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 6;
 
             // LBA
-            CmdBlock->CommandBytes[1] = ((SectorLBA >> 16) & 0x1F);
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[3] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[1] = ((sectorLba >> 16) & 0x1F);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[3] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[4] = NumSectors;
+            commandBlock->CommandBytes[4] = NumSectors;
         } break;
 
         // Read - 10 (IN)
         case SCSI_READ: {
-            uint16_t NumSectors = (uint16_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint16_t NumSectors = (uint16_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 10;
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 10;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[5] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[5] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[7] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[8] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[7] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[8] = (NumSectors & 0xFF);
         } break;
 
         // Read - 12 (IN)
         case SCSI_READ_12: {
-            uint32_t NumSectors = (uint32_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint32_t NumSectors = (uint32_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 12;
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 12;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[5] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[5] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[6] = ((NumSectors >> 24) & 0xFF);
-            CmdBlock->CommandBytes[7] = ((NumSectors >> 16) & 0xFF);
-            CmdBlock->CommandBytes[8] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[9] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[6] = ((NumSectors >> 24) & 0xFF);
+            commandBlock->CommandBytes[7] = ((NumSectors >> 16) & 0xFF);
+            commandBlock->CommandBytes[8] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[9] = (NumSectors & 0xFF);
         } break;
 
         // Read - 16 (IN)
         case SCSI_READ_16: {
-            uint32_t NumSectors = (uint32_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint32_t NumSectors = (uint32_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_IN;
-            CmdBlock->Length = 16;
+            commandBlock->Flags  = MSD_CBW_IN;
+            commandBlock->Length = 16;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 56) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 48) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 40) & 0xFF);
-            CmdBlock->CommandBytes[5] = ((SectorLBA >> 32) & 0xFF);
-            CmdBlock->CommandBytes[6] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[7] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[8] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[9] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 56) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 48) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 40) & 0xFF);
+            commandBlock->CommandBytes[5] = ((sectorLba >> 32) & 0xFF);
+            commandBlock->CommandBytes[6] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[7] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[8] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[9] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[10] = ((NumSectors >> 24) & 0xFF);
-            CmdBlock->CommandBytes[11] = ((NumSectors >> 16) & 0xFF);
-            CmdBlock->CommandBytes[12] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[13] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[10] = ((NumSectors >> 24) & 0xFF);
+            commandBlock->CommandBytes[11] = ((NumSectors >> 16) & 0xFF);
+            commandBlock->CommandBytes[12] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[13] = (NumSectors & 0xFF);
         } break;
 
         // Write - 6 (OUT)
         case SCSI_WRITE_6: {
-            uint8_t NumSectors = (uint8_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint8_t NumSectors = (uint8_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_OUT;
-            CmdBlock->Length = 6;
+            commandBlock->Flags  = MSD_CBW_OUT;
+            commandBlock->Length = 6;
 
             // LBA
-            CmdBlock->CommandBytes[1] = ((SectorLBA >> 16) & 0x1F);
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[3] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[1] = ((sectorLba >> 16) & 0x1F);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[3] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[4] = NumSectors;
+            commandBlock->CommandBytes[4] = NumSectors;
         } break;
 
         // Write - 10 (OUT)
         case SCSI_WRITE: {
-            uint16_t NumSectors = (uint16_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint16_t NumSectors = (uint16_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_OUT;
-            CmdBlock->Length = 10;
+            commandBlock->Flags  = MSD_CBW_OUT;
+            commandBlock->Length = 10;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[5] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[5] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[7] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[8] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[7] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[8] = (NumSectors & 0xFF);
         } break;
 
         // Write - 12 (OUT)
         case SCSI_WRITE_12: {
-            uint32_t NumSectors = (uint32_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint32_t NumSectors = (uint32_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_OUT;
-            CmdBlock->Length = 12;
+            commandBlock->Flags  = MSD_CBW_OUT;
+            commandBlock->Length = 12;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[5] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[5] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[6] = ((NumSectors >> 24) & 0xFF);
-            CmdBlock->CommandBytes[7] = ((NumSectors >> 16) & 0xFF);
-            CmdBlock->CommandBytes[8] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[9] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[6] = ((NumSectors >> 24) & 0xFF);
+            commandBlock->CommandBytes[7] = ((NumSectors >> 16) & 0xFF);
+            commandBlock->CommandBytes[8] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[9] = (NumSectors & 0xFF);
         } break;
 
         // Write - 16 (OUT)
         case SCSI_WRITE_16: {
-            uint32_t NumSectors = (uint32_t)(DataLen / SectorSize);
-            if (DataLen % SectorSize) {
+            uint32_t NumSectors = (uint32_t)(dataLen / sectorSize);
+            if (dataLen % sectorSize) {
                 NumSectors++;
             }
-            CmdBlock->Flags = MSD_CBW_OUT;
-            CmdBlock->Length = 16;
+            commandBlock->Flags  = MSD_CBW_OUT;
+            commandBlock->Length = 16;
 
             // LBA
-            CmdBlock->CommandBytes[2] = ((SectorLBA >> 56) & 0xFF);
-            CmdBlock->CommandBytes[3] = ((SectorLBA >> 48) & 0xFF);
-            CmdBlock->CommandBytes[4] = ((SectorLBA >> 40) & 0xFF);
-            CmdBlock->CommandBytes[5] = ((SectorLBA >> 32) & 0xFF);
-            CmdBlock->CommandBytes[6] = ((SectorLBA >> 24) & 0xFF);
-            CmdBlock->CommandBytes[7] = ((SectorLBA >> 16) & 0xFF);
-            CmdBlock->CommandBytes[8] = ((SectorLBA >> 8) & 0xFF);
-            CmdBlock->CommandBytes[9] = (SectorLBA & 0xFF);
+            commandBlock->CommandBytes[2] = ((sectorLba >> 56) & 0xFF);
+            commandBlock->CommandBytes[3] = ((sectorLba >> 48) & 0xFF);
+            commandBlock->CommandBytes[4] = ((sectorLba >> 40) & 0xFF);
+            commandBlock->CommandBytes[5] = ((sectorLba >> 32) & 0xFF);
+            commandBlock->CommandBytes[6] = ((sectorLba >> 24) & 0xFF);
+            commandBlock->CommandBytes[7] = ((sectorLba >> 16) & 0xFF);
+            commandBlock->CommandBytes[8] = ((sectorLba >> 8) & 0xFF);
+            commandBlock->CommandBytes[9] = (sectorLba & 0xFF);
 
             // Sector Count
-            CmdBlock->CommandBytes[10] = ((NumSectors >> 24) & 0xFF);
-            CmdBlock->CommandBytes[11] = ((NumSectors >> 16) & 0xFF);
-            CmdBlock->CommandBytes[12] = ((NumSectors >> 8) & 0xFF);
-            CmdBlock->CommandBytes[13] = (NumSectors & 0xFF);
+            commandBlock->CommandBytes[10] = ((NumSectors >> 24) & 0xFF);
+            commandBlock->CommandBytes[11] = ((NumSectors >> 16) & 0xFF);
+            commandBlock->CommandBytes[12] = ((NumSectors >> 8) & 0xFF);
+            commandBlock->CommandBytes[13] = (NumSectors & 0xFF);
         } break;
+        default:
+            break;
     }
 }
 
@@ -370,7 +376,7 @@ BulkInitialize(
     }
 
     // Perform a bulk reset
-    if (BulkReset(Device) != OS_EOK) {
+    if (__ResetBulk(Device) != OS_EOK) {
         ERROR("Failed to reset the bulk interface");
         return OS_EUNKNOWN;
     }
@@ -424,11 +430,9 @@ MsdSanitizeResponse(
 
 enum USBTransferCode
 BulkSendCommand(
-        _In_ MsdDevice_t *Device,
-        _In_ uint8_t      ScsiCommand,
-        _In_ uint64_t     SectorStart,
-        _In_ uuid_t       BufferHandle,
-        _In_ size_t       BufferOffset,
+        _In_ MsdDevice_t* device,
+        _In_ uint8_t      scsiCommand,
+        _In_ uint64_t     sectorStart,
         _In_ size_t       DataLength)
 {
     enum USBTransferCode transferResult;
@@ -438,29 +442,29 @@ BulkSendCommand(
 
     // Debug
     TRACE("BulkSendCommand(Command %u, Start %u, Length %u)",
-        ScsiCommand, LODWORD(SectorStart), DataLength);
+          scsiCommand, LODWORD(sectorStart), DataLength);
 
     // Construct our command build the usb transfer
-    BulkScsiCommandConstruct(Device->CommandBlock, ScsiCommand, SectorStart, 
-        DataLength, (uint16_t)Device->Descriptor.SectorSize);
+    __ConstructSCSICommand(device->CommandBlock, scsiCommand, sectorStart,
+                           DataLength, (uint16_t) device->Descriptor.SectorSize);
     UsbTransferInitialize(
             &CommandStage,
-            &Device->Device->DeviceContext,
-            Device->Out,
+            &device->Device->DeviceContext,
+            device->Out,
             USBTRANSFER_TYPE_BULK,
             USBTRANSFER_DIRECTION_OUT,
             0,
             dma_pool_handle(UsbRetrievePool()),
-            dma_pool_offset(UsbRetrievePool(), Device->CommandBlock),
+            dma_pool_offset(UsbRetrievePool(), device->CommandBlock),
             sizeof(MsdCommandBlock_t)
     );
 
-    oserr = UsbTransferQueue(&Device->Device->DeviceContext, &CommandStage, &transferResult, &bytesTransferred);
+    oserr = UsbTransferQueue(&device->Device->DeviceContext, &CommandStage, &transferResult, &bytesTransferred);
     if (oserr != OS_EOK || transferResult != USBTRANSFERCODE_SUCCESS) {
         ERROR("Failed to send the CBW command, transfer-code %u/%u", oserr, transferResult);
         if (transferResult == USBTRANSFERCODE_STALL) {
             ERROR("Performing a recovery-reset on device.");
-            if (BulkResetRecovery(Device, BULK_RESET_ALL) != OS_EOK) {
+            if (__ResetRecovery(device, BULK_RESET_ALL) != OS_EOK) {
                 ERROR("Failed to reset device, it is now unusable.");
             }
         }
@@ -468,8 +472,6 @@ BulkSendCommand(
     return transferResult;
 }
 
-/* BulkReadData
- * Tries to read a bulk data response from the device. */
 enum USBTransferCode
 BulkReadData(
         _In_  MsdDevice_t* Device,
@@ -482,6 +484,7 @@ BulkReadData(
     USBTransfer_t        dataStage;
     size_t               bytesTransferred = 0;
     oserr_t              oserr;
+    TRACE("BulkReadData(length=%u)", DataLength);
 
     UsbTransferInitialize(
             &dataStage,
@@ -502,11 +505,11 @@ BulkReadData(
     if (oserr != OS_EOK || transferStatus != USBTRANSFERCODE_SUCCESS) {
         ERROR("Data-stage failed with status %u/%u, cleaning up bulk-in", oserr, transferStatus);
         if (transferStatus == USBTRANSFERCODE_STALL) {
-            BulkResetRecovery(Device, BULK_RESET_IN);
+            __ResetRecovery(Device, BULK_RESET_IN);
         }
         else {
             // Fatal error
-            BulkResetRecovery(Device, BULK_RESET_ALL);
+            __ResetRecovery(Device, BULK_RESET_ALL);
         }
     }
 
@@ -515,49 +518,67 @@ BulkReadData(
     return transferStatus;
 }
 
-enum USBTransferCode
+oserr_t
 BulkWriteData(
-        _In_  MsdDevice_t* Device,
-        _In_  uuid_t       BufferHandle,
-        _In_  size_t       BufferOffset,
-        _In_  size_t       DataLength,
-        _Out_ size_t*      BytesWritten)
+        _In_  MsdDevice_t*          device,
+        _In_  uuid_t                bufferHandle,
+        _In_  size_t                bufferOffset,
+        _In_  size_t                dataLength,
+        _Out_ size_t*               bytesWrittenOut,
+        _Out_ enum USBTransferCode* transferCodeOut)
 {
     enum USBTransferCode transferResult;
     USBTransfer_t        DataStage;
     size_t               bytesTransferred;
     oserr_t              oserr;
+    TRACE("BulkReadData(length=%u)", dataLength);
 
     // Perform the data-stage
     UsbTransferInitialize(
             &DataStage,
-            &Device->Device->DeviceContext,
-            Device->Out,
+            &device->Device->DeviceContext,
+            device->Out,
             USBTRANSFER_TYPE_BULK,
             USBTRANSFER_DIRECTION_OUT,
             0,
-            BufferHandle,
-            BufferOffset,
-            DataLength
+            bufferHandle,
+            bufferOffset,
+            dataLength
     );
 
-    oserr = UsbTransferQueue(&Device->Device->DeviceContext, &DataStage, &transferResult, &bytesTransferred);
+    oserr = UsbTransferQueue(
+            &device->Device->DeviceContext,
+            &DataStage,
+            &transferResult,
+            &bytesTransferred
+    );
+    if (oserr != OS_EOK) {
+        // If this error is not OK, then it was not a transport error, but rather something
+        // critical with our setup. There is only one error we can fix, and that's if the buffer
+        // was invalid. That means the user-supplied buffer was using an offset that causes the
+        // buffer to cross boundary, and this is not always supported.
+        if (oserr == OS_EBUFFER) {
+            // Allocate a temporary transport buffer, there will be no chance of crossing boundaries
+            // here as we always transport in sector sizes.
+
+        }
+
+        // Otherwise something was totally wrong, return an error
+        return USBTRANSFERCODE_CANCELLED;
+    }
+
     // Sanitize for any transport errors
     // The host shall accept the data received.
     // The host shall clear the Bulk-In pipe.
-    if (oserr != OS_EOK || transferResult != USBTRANSFERCODE_SUCCESS) {
+    if (transferResult != USBTRANSFERCODE_SUCCESS) {
         ERROR("Data-stage failed with status %u/%u, cleaning up bulk-out", oserr, transferResult);
         if (transferResult == USBTRANSFERCODE_STALL) {
-            BulkResetRecovery(Device, BULK_RESET_OUT);
-        }
-        else {
-            // Fatal error
-            BulkResetRecovery(Device, BULK_RESET_ALL);
+            __ResetRecovery(device, BULK_RESET_OUT);
+        } else {
+            __ResetRecovery(device, BULK_RESET_ALL);
         }
     }
-
-    // Return state
-    *BytesWritten = bytesTransferred;
+    *bytesWrittenOut = bytesTransferred;
     return transferResult;
 }
 
@@ -590,7 +611,7 @@ BulkGetStatus(
     // The host shall again attempt to receive the CSW.
     if (oserr != OS_EOK || transferResult != USBTRANSFERCODE_SUCCESS) {
         if (oserr == OS_EOK && transferResult == USBTRANSFERCODE_STALL) {
-            BulkResetRecovery(Device, BULK_RESET_IN);
+            __ResetRecovery(Device, BULK_RESET_IN);
             return BulkGetStatus(Device);
         } else {
             ERROR("Failed to retrieve the CSW block, transfer-code %u", transferResult);

--- a/modules/storage/msd/protocols/bulk.c
+++ b/modules/storage/msd/protocols/bulk.c
@@ -19,7 +19,7 @@
  *  - Bulk Protocol Implementation
  */
 
-#define __TRACE
+//#define __TRACE
 
 #define BULK_RESET      0x1
 #define BULK_RESET_IN   0x2
@@ -503,7 +503,6 @@ __ReadData(
 {
     enum USBTransferCode transferCode;
     USBTransfer_t        dataStage;
-    size_t               bytesTransferred = 0;
     oserr_t              oserr;
     TRACE("__ReadData(length=%u)", dataLength);
 
@@ -523,7 +522,7 @@ __ReadData(
             &device->Device->DeviceContext,
             &dataStage,
             &transferCode,
-            &bytesTransferred
+            bytesRead
     );
     // Sanitize for any transport errors
     // The host shall accept the data received.
@@ -537,9 +536,7 @@ __ReadData(
             __ResetRecovery(device, BULK_RESET_ALL);
         }
     }
-
     *transferCodeOut = transferCode;
-    *bytesRead = bytesTransferred;
     return oserr;
 }
 
@@ -554,9 +551,8 @@ __WriteData(
 {
     enum USBTransferCode transferCode;
     USBTransfer_t        DataStage;
-    size_t               bytesTransferred;
     oserr_t              oserr;
-    TRACE("__ReadData(length=%u)", dataLength);
+    TRACE("__WriteData(length=%u)", dataLength);
 
     // Perform the data-stage
     UsbTransferInitialize(
@@ -575,7 +571,7 @@ __WriteData(
             &device->Device->DeviceContext,
             &DataStage,
             &transferCode,
-            &bytesTransferred
+            bytesWrittenOut
     );
     if (oserr != OS_EOK) {
         return oserr;
@@ -592,9 +588,7 @@ __WriteData(
             __ResetRecovery(device, BULK_RESET_ALL);
         }
     }
-
     *transferCodeOut = transferCode;
-    *bytesWrittenOut = bytesTransferred;
     return oserr;
 }
 
@@ -604,13 +598,13 @@ __GetStatus(
         _Out_ enum USBTransferCode* transferCodeOut)
 {
     enum USBTransferCode transferCode;
-    USBTransfer_t        StatusStage;
+    USBTransfer_t        statusStage;
     size_t               bytesTransferred;
     oserr_t              oserr;
     TRACE("__GetStatus()");
 
     UsbTransferInitialize(
-            &StatusStage,
+            &statusStage,
             &device->Device->DeviceContext,
             device->In,
             USBTRANSFER_TYPE_BULK,
@@ -623,7 +617,7 @@ __GetStatus(
 
     oserr = UsbTransferQueue(
             &device->Device->DeviceContext,
-            &StatusStage,
+            &statusStage,
             &transferCode,
             &bytesTransferred
     );

--- a/modules/storage/msd/protocols/ufi.c
+++ b/modules/storage/msd/protocols/ufi.c
@@ -135,8 +135,6 @@ UfiSendCommand(
         _In_ MsdDevice_t* Device,
         _In_ uint8_t      ScsiCommand,
         _In_ uint64_t     SectorStart,
-        _In_ uuid_t       BufferHandle,
-        _In_ size_t       BufferOffset,
         _In_ size_t       DataLength)
 {
     MsdCommandBlockUFI_t UfiCommandBlock;

--- a/services/deviced/discover/discover.c
+++ b/services/deviced/discover/discover.c
@@ -51,7 +51,7 @@ struct DmDriver {
     struct usched_mtx            devices_lock;
 };
 
-struct DmDevice {
+struct DMDevice {
     element_t list_header;
     uuid_t    id;
 };
@@ -177,10 +177,10 @@ __RegisterDeviceForDriver(
         _In_ struct DmDriver* driver,
         _In_ uuid_t           deviceId)
 {
-    struct DmDevice* device;
+    struct DMDevice* device;
     TRACE("__RegisterDeviceForDriver()");
 
-    device = malloc(sizeof(struct DmDevice));
+    device = malloc(sizeof(struct DMDevice));
     if (!device) {
         return;
     }
@@ -280,7 +280,7 @@ __NotifyDevices(
 {
     usched_mtx_lock(&driver->devices_lock);
     foreach (i, &driver->devices) {
-        struct DmDevice* device = i->value;
+        struct DMDevice* device = i->value;
         oserr_t          oserr  = DmDevicesRegister(driver->handle, device->id);
         if (oserr != OS_EOK) {
             WARNING("__NotifyDevices failed to notify driver of device %u", device->id);

--- a/services/processd/pe/mapper.c
+++ b/services/processd/pe/mapper.c
@@ -408,7 +408,7 @@ MapperLoadModule(
     }
 
     // Calculate the image delta for processings
-    DEBUG("MapperLoadModule(%ms) loaded at 0x%" PRIxIN, path, baseAddress);
+    NOTICE("MapperLoadModule(%ms) loaded at 0x%" PRIxIN, path, baseAddress);
     imageDelta = (baseAddress - module->ImageBase);
 
     // Run fixup's on the new mappings

--- a/services/served/server/install.c
+++ b/services/served/server/install.c
@@ -163,7 +163,7 @@ oserr_t InstallApplication(mstring_t* path, const char* basename)
     struct Application* application;
     mstring_t*          publisher;
     oserr_t             oserr;
-    TRACE("InstallApplication(path=%ms, basename=%s)", path, basename);
+    DEBUG("InstallApplication(path=%ms, basename=%s)", path, basename);
 
     oserr = __GetPublisher(basename, &publisher);
     if (oserr != OS_EOK) {
@@ -186,7 +186,7 @@ void InstallBundledApplications(void)
 {
     struct DIR*    setupDir;
     struct dirent* entry;
-    TRACE("InstallBundledApplications()");
+    DEBUG("InstallBundledApplications()");
 
     setupDir = opendir("/data/setup");
     if (setupDir == NULL) {
@@ -214,4 +214,5 @@ void InstallBundledApplications(void)
     if (unlink("/data/setup")) {
         ERROR("InstallBundledApplications failed to remove /data/setup: %i", errno);
     }
+    DEBUG("InstallBundledApplications: bundled applications has been installed");
 }

--- a/services/usbd/devices.c
+++ b/services/usbd/devices.c
@@ -254,16 +254,23 @@ __QueryInitialDeviceDescriptor(
         _In_ UsbPortDevice_t* device)
 {
     usb_device_descriptor_t deviceDescriptor;
-    enum USBTransferCode     status;
+    enum USBTransferCode    status;
 
+    // Query the initial 8 bytes of the configuration descriptor, to get the correct
+    // control size. There is no reason to query the full descriptor, and this way
+    // we dont need a variable buffer size.
     status = UsbExecutePacket(
             &device->Base,
             USBPACKET_DIRECTION_IN,
             USBPACKET_TYPE_GET_DESC,
             0, USB_DESCRIPTOR_DEVICE,
-            0, device->Base.device_mps,
+            0,
+            8,
             &deviceDescriptor
     );
+    if (status == USBTRANSFERCODE_SUCCESS) {
+        device->Base.device_mps = deviceDescriptor.MaxPacketSize;
+    }
     return status;
 }
 

--- a/services/usbd/devices.c
+++ b/services/usbd/devices.c
@@ -280,11 +280,11 @@ UsbCoreDevicesCreate(
     _In_ UsbHub_t*        usbHub,
     _In_ UsbPort_t*       usbPort)
 {
-    USBPortDescriptor_t portDescriptor;
+    USBPortDescriptor_t  portDescriptor;
     enum USBTransferCode usbStatus;
-    oserr_t               oserr;
-    UsbPortDevice_t*      device;
-    int                   reservedAddress = 0;
+    oserr_t              oserr;
+    UsbPortDevice_t*     device;
+    int                  reservedAddress = 0;
 
     TRACE("[usb] [%u:%u] setting up", usbHub->PortAddress, usbPort->Address);
 
@@ -316,9 +316,9 @@ UsbCoreDevicesCreate(
     }
 
     // Update port
-    usbPort->Connected                = 1;
-    usbPort->Enabled                  = 1;
-    usbPort->Speed                    = portDescriptor.Speed;
+    usbPort->Connected = 1;
+    usbPort->Enabled   = 1;
+    usbPort->Speed     = portDescriptor.Speed;
     
     // Initialize the members we have, leave device address to 0
     device->Base.controller_device_id = usbController->Device->Id;

--- a/services/usbd/port_event.c
+++ b/services/usbd/port_event.c
@@ -77,8 +77,7 @@ void __HandlePortEvent(
         if (oserr != OS_EOK) {
             // TODO
         }
-    }
-    else if (portDescriptor.Connected == 0 && port->Connected == 1) {
+    } else if (portDescriptor.Connected == 0 && port->Connected == 1) {
         // Disconnected event, remember that the descriptor pointer
         // becomes unavailable the moment we call the destroy device
         oserr = UsbCoreDevicesDestroy(controller, port);
@@ -89,8 +88,7 @@ void __HandlePortEvent(
         port->Speed     = portDescriptor.Speed;              // TODO: invalid
         port->Enabled   = portDescriptor.Enabled;            // TODO: invalid
         port->Connected = portDescriptor.Connected;          // TODO: invalid
-    }
-    else {
+    } else {
         // Ignore
         port->Speed     = portDescriptor.Speed;
         port->Enabled   = portDescriptor.Enabled;

--- a/tools/depends.sh
+++ b/tools/depends.sh
@@ -22,6 +22,9 @@ install_cmake() {
           elif [ -d "/usr/local/share/cmake-${regex_match}" ]; then
               echo "** updating cmake platform in path /usr/local/share/cmake-${regex_match}"
               cp --verbose "$SCRIPTPATH"/*.cmake /usr/local/share/cmake-"${regex_match}"/Modules/Platform/
+          elif [ -d "/usr/share/cmake" ]; then
+              echo "** updating cmake platform in path /usr/share/cmake"
+              cp --verbose "$SCRIPTPATH"/*.cmake /usr/share/cmake/Modules/Platform/
           fi
   else
       echo "** ERROR: unknown cmake version that regex did not match ${CMAKE_VERSION}"

--- a/tools/setup.bochsrc
+++ b/tools/setup.bochsrc
@@ -85,12 +85,12 @@
 #display_library: nogui
 #display_library: rfb
 #display_library: sdl, options="fullscreen" # startup in fullscreen mode
-#display_library: sdl2, options="fullscreen" # startup in fullscreen mode
+display_library: sdl2
 #display_library: term
 #display_library: vncsrv
 #display_library: win32
 #display_library: wx
-display_library: x
+#display_library: x
 
 #=======================================================================
 # CPU:

--- a/tools/setup.bochsrc
+++ b/tools/setup.bochsrc
@@ -944,10 +944,9 @@ parport1: enabled=1, file="parport.out"
 # syntax as the UHCI controller (see above). The optionsX parameter is also
 # available on OHCI.
 #=======================================================================
-usb_ohci: enabled=1, port1=disk:disk_usb.img
+usb_ohci: enabled=1,
+usb_ohci: port1=disk:flat:disk_usb.img, options1="debug,speed:full"
 
-#usb_ohci: enabled=1
-#usb_ohci: enabled=1, port1=printer:usbprinter.bin
 
 #=======================================================================
 # USB_EHCI:


### PR DESCRIPTION
This PR is set to fix all the remaining USB issues leftover by the previous PR which refactored most of the USB common code.

Bugfixes:
- Fixed OHCI transfer descriptors not being limited to MPS.
- Fixed issues with how USB packet memory was copied.
- Fixed how address and length was calculated for individual TDs

Improvements:
- Implement usage of BufferAlignment for UHCI to properly support buffers going across pages
- Better support for error handling in the USB stack by returning both oserr + transfer code
- Cleanup in the MSD driver
