### PR TITLE
vali: fix SHM memory buffer issues

### DIFF
--- a/kernel/include/handle.h
+++ b/kernel/include/handle.h
@@ -110,7 +110,7 @@ AcquireHandleOfType(
  */
 KERNELAPI void* KERNELABI
 LookupHandleOfType(
-        _In_ uuid_t       handleId,
-        _In_ HandleType_t handleType);
+        _In_ uuid_t       ID,
+        _In_ HandleType_t type);
 
 #endif //! __HANDLE_H__

--- a/kernel/memory/heap.c
+++ b/kernel/memory/heap.c
@@ -720,8 +720,7 @@ MemoryCacheAllocate(
             if (Slab->NumberOfFreeObjects == 1) {
                 list_remove(&Cache->PartialSlabs, Element);
             }
-        }
-        else {
+        } else {
             Element = list_front(&Cache->FreeSlabs);
             assert(Element != NULL);
             
@@ -741,8 +740,7 @@ MemoryCacheAllocate(
         Cache->NumberOfFreeObjects--;
         
         Allocated = MEMORY_SLAB_ELEMENT(Cache, Slab, Index);
-    }
-    else if (!(Cache->Flags & HEAP_SINGLE_SLAB)) {
+    } else if (!(Cache->Flags & HEAP_SINGLE_SLAB)) {
         Slab = __SlabCreate(Cache);
         if (!Slab) {
             MutexUnlock(&Cache->SyncObject);
@@ -755,15 +753,13 @@ MemoryCacheAllocate(
         
         if (!Slab->NumberOfFreeObjects) {
             list_append(&Cache->FullSlabs, &Slab->Header);
-        }
-        else {
+        } else {
             list_append(&Cache->PartialSlabs, &Slab->Header);
             Cache->NumberOfFreeObjects += (Cache->ObjectCount - 1);
         }
         
         Allocated = MEMORY_SLAB_ELEMENT(Cache, Slab, Index);
-    }
-    else {
+    } else {
         ERROR("[heap] [%s] ran out of objects %i/%i", Cache->Name,
             Cache->NumberOfFreeObjects, Cache->ObjectCount);
         Allocated = NULL;

--- a/kernel/sync/mutex.c
+++ b/kernel/sync/mutex.c
@@ -102,6 +102,8 @@ __SlowLock(
     irqstate_t intStatus;
     uuid_t     owner;
 
+    // TODO: Detect mutex locking during IRQs
+
     // Disable interrupts and try to acquire the lock or wait for the lock
     // to unlock if it's held on another CPU - however we only wait for a brief period
     intStatus = InterruptDisable();

--- a/librt/libc/stdio/fread.c
+++ b/librt/libc/stdio/fread.c
@@ -15,8 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//#define __TRACE
 #define __need_minmax
-#define __TRACE
 #include <ddk/utils.h>
 #include <errno.h>
 #include <internal/_file.h>

--- a/librt/libc/stdio/fwrite.c
+++ b/librt/libc/stdio/fwrite.c
@@ -15,9 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//#define __TRACE
 #define __need_minmax
-#define __TRACE
-
 #include <ddk/utils.h>
 #include <errno.h>
 #include <io.h>

--- a/librt/libddk/include/ddk/barrier.h
+++ b/librt/libddk/include/ddk/barrier.h
@@ -78,7 +78,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 //// Clang
 ///////////////////////////////////////////////////////////////////////////////
-#elif defined(__clang__)
+#elif defined(__clang__) || defined(__GNUC__)
 #define sw_mb()  __asm__ __volatile__ ( "" ::: "memory" )
 #define sw_rmb() __asm__ __volatile__ ( "" ::: "memory" )
 #define sw_wmb() __asm__ __volatile__ ( "" ::: "memory" )

--- a/librt/libos/include/os/shm.h
+++ b/librt/libos/include/os/shm.h
@@ -159,6 +159,18 @@ SHMBufferCapacity(
         _In_ OSHandle_t* handle));
 
 /**
+ * @brief Returns the current offset in use for the shared memory buffer handle.
+ * The value returned is only valid for buffers that have been mapped, or exported.
+ * That means either SHMMap, SHMConform or SHMExport must have been called on this
+ * handle.
+ * @param[In] handle The OS handle that represents a SHM buffer.
+ * @return The current offset into the underlying buffer region this mapping represents.
+ */
+CRTDECL(size_t,
+SHMBufferOffset(
+        _In_ OSHandle_t* handle));
+
+/**
  * Call this once with the count parameter to get the number of
  * scatter-gather entries, then the second time with the memory_sg parameter
  * to retrieve a list of all the entries

--- a/librt/libos/shm.c
+++ b/librt/libos/shm.c
@@ -304,6 +304,28 @@ SHMBufferLength(
 }
 
 size_t
+SHMBufferOffset(
+        _In_ OSHandle_t* handle)
+{
+    SHMHandle_t* shm;
+    if (handle == NULL || handle->Payload == NULL) {
+        return 0;
+    }
+    // The offset in the handle can mean two different things, either
+    // it means the actual offset the buffer was mapped with, or it means
+    // the offset into the source buffer. (Conforming buffers use this).
+    // This means that conformed buffers always have an effective offset of
+    // 0, so handle this correctly on a userspace level.
+    shm = handle->Payload;
+    if (shm->SourceID != UUID_INVALID) {
+        // The buffer is a conformed buffer, they *always* have effective
+        // offsets of 0.
+        return 0;
+    }
+    return shm->Offset;
+}
+
+size_t
 SHMBufferCapacity(
         _In_ OSHandle_t* handle)
 {

--- a/modules/filesystems/common/storage.c
+++ b/modules/filesystems/common/storage.c
@@ -16,7 +16,7 @@
  *
  */
 
-#define __TRACE
+//#define __TRACE
 
 #include <ddk/convert.h>
 #include <ddk/utils.h>

--- a/modules/filesystems/mfs/main.c
+++ b/modules/filesystems/mfs/main.c
@@ -144,33 +144,34 @@ FsStat(
 
 oserr_t
 FsUnlink(
-        _In_  void*     instanceData,
+        _In_ void*      instanceData,
         _In_ mstring_t* path)
 {
     FileSystemMFS_t* mfs = instanceData;
-    oserr_t          osStatus;
+    oserr_t          oserr;
     MFSEntry_t*      mfsEntry;
+    TRACE("FsUnlink(%ms)", path);
 
-    osStatus = MfsLocateRecord(
+    oserr = MfsLocateRecord(
             mfs,
             &mfs->RootEntry,
             path,
             &mfsEntry);
-    if (osStatus != OS_EOK) {
-        return osStatus;
+    if (oserr != OS_EOK) {
+        return oserr;
     }
 
-    osStatus = MfsFreeBuckets(mfs, mfsEntry->StartBucket, mfsEntry->StartLength);
-    if (osStatus != OS_EOK) {
+    oserr = MfsFreeBuckets(mfs, mfsEntry->StartBucket, mfsEntry->StartLength);
+    if (oserr != OS_EOK) {
         ERROR("Failed to free the buckets at start 0x%x, length 0x%x",
               mfsEntry->StartBucket, mfsEntry->StartLength);
         goto cleanup;
     }
 
-    osStatus = MfsUpdateRecord(mfs, mfsEntry, MFS_ACTION_DELETE);
+    oserr = MfsUpdateRecord(mfs, mfsEntry, MFS_ACTION_DELETE);
 cleanup:
     MFSEntryDelete(mfsEntry);
-    return osStatus;
+    return oserr;
 }
 
 oserr_t

--- a/modules/filesystems/mfs/records.c
+++ b/modules/filesystems/mfs/records.c
@@ -21,7 +21,7 @@
  *  - Contains the implementation of the MFS driver for mollenos
  */
 
-#define __TRACE
+//#define __TRACE
 
 #include <ddk/utils.h>
 #include <fs/common.h>
@@ -211,6 +211,7 @@ __FindEntryOrFreeInDirectory(
         MapRecord_t   link;
         int           exitLoop = 0;
 
+        TRACE("__FindEntryOrFreeInDirectory: reading bucket %u", currentBucket);
         oserr = __ReadCurrentBucket(mfs, currentBucket, &link);
         if (oserr != OS_EOK) {
             ERROR("__FindEntryOrFreeInDirectory failed to read directory bucket");
@@ -505,21 +506,21 @@ MfsCreateRecord(
         _In_  uint32_t         startLength,
         _Out_ MFSEntry_t**     entryOut)
 {
-    oserr_t    osStatus;
+    oserr_t    oserr;
     MFSEntry_t nextEntry = { 0 };
 
     TRACE("MfsCreateRecord(fileSystem=%ms, flags=0x%x, path=%ms)",
           mfs->Label, flags, name);
 
-    osStatus = __FindEntryOrFreeInDirectory(
+    oserr = __FindEntryOrFreeInDirectory(
             mfs,
             entry,
             name,
             1,
             &nextEntry
     );
-    if (osStatus == OS_ENOENT) {
-        osStatus = __CreateEntryInDirectory(
+    if (oserr == OS_ENOENT) {
+        oserr = __CreateEntryInDirectory(
                 mfs,
                 name,
                 owner,
@@ -536,6 +537,6 @@ MfsCreateRecord(
         );
     }
     __CleanupEntryIterator(&nextEntry);
-    TRACE("MfsCreateRecord returns=%u", osStatus);
-    return osStatus;
+    TRACE("MfsCreateRecord returns=%u", oserr);
+    return oserr;
 }

--- a/modules/filesystems/mfs/utilities.c
+++ b/modules/filesystems/mfs/utilities.c
@@ -21,7 +21,7 @@
  *  - Contains the implementation of the MFS driver for mollenos
  */
 
-#define __TRACE
+//#define __TRACE
 
 #include <ddk/utils.h>
 #include <fs/common.h>
@@ -97,7 +97,7 @@ MfsUpdateRecord(
     oserr_t       oserr;
     FileRecord_t* record;
     size_t        sectorsTransferred;
-    TRACE("MfsUpdateEntry(File %ms)", entry->Name);
+    TRACE("MfsUpdateEntry(entry=%ms, action=%i)", entry->Name, action);
 
     // Read the stored data bucket where the record is
     oserr = FSStorageRead(

--- a/services/filed/vfs/vfs.c
+++ b/services/filed/vfs/vfs.c
@@ -288,10 +288,8 @@ void VFSNodeDestroy(struct VFSNode* node)
     hashtable_destroy(&node->Mounts);
 
     mstr_delete(node->Name);
-    mstr_delete(node->Stats.Name);
-    if (node->Stats.LinkTarget != NULL) {
-        mstr_delete(node->Stats.LinkTarget);
-    }
+    // Stats.Name is a pointer to .Name
+    mstr_delete(node->Stats.LinkTarget);
     free(node);
 }
 


### PR DESCRIPTION
Bugs discovered in the wake of the SHMConform implementation, and some pre-existing ones.

Bugfixes:
- Fixed usage of SHMConform functionality not being entirely correct, for filesystems.
- Fixed memory allocation issue in DestroyHandle, which caused a deadlock as it was calling the heap.
- Fixed a memory map issue in SHMMap where we failed to take the page-offset into account in the length.
- Fixed a bug in the bucket_map for MFS.
- Fixed two bugs related to file-removal.